### PR TITLE
Fixed CMake script

### DIFF
--- a/src/SFML/CMakeLists.txt
+++ b/src/SFML/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/Macros.cmake)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
 # define the path of our additional CMake modules
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # set the output directory for CSFML libraries
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")


### PR DESCRIPTION
CMAKE_MODULE_PATH should not be overwritten, paths should be added to it.
