### PR TITLE
Removed export macros in the function definitions

### DIFF
--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -196,7 +196,7 @@ sfVector3f sfSound_getPosition(const sfSound* sound)
 
 
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API sfBool sfSound_isRelativeToListener(const sfSound* sound)
+sfBool sfSound_isRelativeToListener(const sfSound* sound)
 {
     CSFML_CALL_RETURN(sound, isRelativeToListener(), sfFalse);
 }

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -63,7 +63,7 @@ sfSoundBuffer* sfSoundBuffer_createFromMemory(const void* data, size_t sizeInByt
 
 
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_createFromStream(sfInputStream* stream)
+sfSoundBuffer* sfSoundBuffer_createFromStream(sfInputStream* stream)
 {
     CSFML_CHECK_RETURN(stream, NULL);
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -178,7 +178,7 @@ sfVector3f sfSoundStream_getPosition(const sfSoundStream* soundStream)
 
 
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API sfBool sfSoundStream_isRelativeToListener(const sfSoundStream* soundStream)
+sfBool sfSoundStream_isRelativeToListener(const sfSoundStream* soundStream)
 {
     CSFML_CALL_RETURN(soundStream, isRelativeToListener(), sfFalse);
 }


### PR DESCRIPTION
@eXpl0it3r discovered these when he was building CSFML with VS2010. These caused a C2491 (http://msdn.microsoft.com/en-us/library/62688esh.aspx) error to be thrown.
