### PR TITLE
Compile with OS X 10.10

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -22,7 +22,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
     EXEC_PROGRAM(/usr/bin/sw_vers ARGS -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
-    STRING(REGEX REPLACE "10\\.([0-9]).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
+    STRING(REGEX REPLACE "10\\.([0-9]+).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
     if(${MACOSX_VERSION} LESS 5)
         message(FATAL_ERROR "Unsupported version of OS X : ${MACOSX_VERSION_RAW}")
         return()


### PR DESCRIPTION
Fixes the OS X version detection regex to allow compiling under OS X
10.10+.

I'm not sure it doesn't break anything, but it works fine for me.
