### PR TITLE
Use size_t instead of unsigned int to follow SFML change

### DIFF
--- a/include/SFML/Audio/SoundBuffer.h
+++ b/include/SFML/Audio/SoundBuffer.h
@@ -92,7 +92,7 @@ CSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_createFromStream(sfInputStream* str
 /// \return A new sfSoundBuffer object (NULL if failed)
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_createFromSamples(const sfInt16* samples, size_t sampleCount, unsigned int channelCount, unsigned int sampleRate);
+CSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_createFromSamples(const sfInt16* samples, sfUint64 sampleCount, unsigned int channelCount, unsigned int sampleRate);
 
 ////////////////////////////////////////////////////////////
 /// \brief Create a new sound buffer by copying an existing one

--- a/include/SFML/Graphics/CircleShape.h
+++ b/include/SFML/Graphics/CircleShape.h
@@ -34,6 +34,7 @@
 #include <SFML/Graphics/Transform.h>
 #include <SFML/Graphics/Types.h>
 #include <SFML/System/Vector2.h>
+#include <stddef.h>
 
 
 ////////////////////////////////////////////////////////////
@@ -352,7 +353,7 @@ CSFML_GRAPHICS_API float sfCircleShape_getOutlineThickness(const sfCircleShape* 
 /// \return Number of points of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API unsigned int sfCircleShape_getPointCount(const sfCircleShape* shape);
+CSFML_GRAPHICS_API size_t sfCircleShape_getPointCount(const sfCircleShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get a point of a circle shape
@@ -365,7 +366,7 @@ CSFML_GRAPHICS_API unsigned int sfCircleShape_getPointCount(const sfCircleShape*
 /// \return Index-th point of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfVector2f sfCircleShape_getPoint(const sfCircleShape* shape, unsigned int index);
+CSFML_GRAPHICS_API sfVector2f sfCircleShape_getPoint(const sfCircleShape* shape, size_t index);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the radius of a circle
@@ -393,7 +394,7 @@ CSFML_GRAPHICS_API float sfCircleShape_getRadius(const sfCircleShape* shape);
 /// \param count New number of points of the circle
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfCircleShape_setPointCount(sfCircleShape* shape, unsigned int count);
+CSFML_GRAPHICS_API void sfCircleShape_setPointCount(sfCircleShape* shape, size_t count);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the local bounding rectangle of a circle shape

--- a/include/SFML/Graphics/ConvexShape.h
+++ b/include/SFML/Graphics/ConvexShape.h
@@ -34,6 +34,7 @@
 #include <SFML/Graphics/Transform.h>
 #include <SFML/Graphics/Types.h>
 #include <SFML/System/Vector2.h>
+#include <stddef.h>
 
 
 ////////////////////////////////////////////////////////////
@@ -352,7 +353,7 @@ CSFML_GRAPHICS_API float sfConvexShape_getOutlineThickness(const sfConvexShape* 
 /// \return Number of points of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API unsigned int sfConvexShape_getPointCount(const sfConvexShape* shape);
+CSFML_GRAPHICS_API size_t sfConvexShape_getPointCount(const sfConvexShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get a point of a convex shape
@@ -365,7 +366,7 @@ CSFML_GRAPHICS_API unsigned int sfConvexShape_getPointCount(const sfConvexShape*
 /// \return Index-th point of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape, unsigned int index);
+CSFML_GRAPHICS_API sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape, size_t index);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the number of points of a convex shap
@@ -376,7 +377,7 @@ CSFML_GRAPHICS_API sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape,
 /// \param count New number of points of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfConvexShape_setPointCount(sfConvexShape* shape, unsigned int count);
+CSFML_GRAPHICS_API void sfConvexShape_setPointCount(sfConvexShape* shape, size_t count);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a point in a convex shape
@@ -392,7 +393,7 @@ CSFML_GRAPHICS_API void sfConvexShape_setPointCount(sfConvexShape* shape, unsign
 /// \param point New point
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfConvexShape_setPoint(sfConvexShape* shape, unsigned int index, sfVector2f point);
+CSFML_GRAPHICS_API void sfConvexShape_setPoint(sfConvexShape* shape, size_t index, sfVector2f point);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the local bounding rectangle of a convex shape

--- a/include/SFML/Graphics/RectangleShape.h
+++ b/include/SFML/Graphics/RectangleShape.h
@@ -34,6 +34,7 @@
 #include <SFML/Graphics/Transform.h>
 #include <SFML/Graphics/Types.h>
 #include <SFML/System/Vector2.h>
+#include <stddef.h>
 
 
 ////////////////////////////////////////////////////////////
@@ -352,7 +353,7 @@ CSFML_GRAPHICS_API float sfRectangleShape_getOutlineThickness(const sfRectangleS
 /// \return Number of points of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API unsigned int sfRectangleShape_getPointCount(const sfRectangleShape* shape);
+CSFML_GRAPHICS_API size_t sfRectangleShape_getPointCount(const sfRectangleShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get a point of a rectangle shape
@@ -365,7 +366,7 @@ CSFML_GRAPHICS_API unsigned int sfRectangleShape_getPointCount(const sfRectangle
 /// \return Index-th point of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfVector2f sfRectangleShape_getPoint(const sfRectangleShape* shape, unsigned int index);
+CSFML_GRAPHICS_API sfVector2f sfRectangleShape_getPoint(const sfRectangleShape* shape, size_t index);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the size of a rectangle shape

--- a/include/SFML/Graphics/RenderTexture.h
+++ b/include/SFML/Graphics/RenderTexture.h
@@ -36,6 +36,7 @@
 #include <SFML/Graphics/RenderStates.h>
 #include <SFML/Graphics/Vertex.h>
 #include <SFML/System/Vector2.h>
+#include <stddef.h>
 
 
 ////////////////////////////////////////////////////////////
@@ -216,7 +217,7 @@ CSFML_GRAPHICS_API void sfRenderTexture_drawVertexArray(sfRenderTexture* renderT
 ///
 ////////////////////////////////////////////////////////////
 CSFML_GRAPHICS_API void sfRenderTexture_drawPrimitives(sfRenderTexture* renderTexture,
-                                                       const sfVertex* vertices, unsigned int vertexCount,
+                                                       const sfVertex* vertices, size_t vertexCount,
                                                        sfPrimitiveType type, const sfRenderStates* states);
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/RenderWindow.h
+++ b/include/SFML/Graphics/RenderWindow.h
@@ -40,6 +40,7 @@
 #include <SFML/Window/WindowHandle.h>
 #include <SFML/Window/Window.h>
 #include <SFML/System/Vector2.h>
+#include <stddef.h>
 
 
 ////////////////////////////////////////////////////////////
@@ -441,7 +442,7 @@ CSFML_GRAPHICS_API void sfRenderWindow_drawVertexArray(sfRenderWindow* renderWin
 ///
 ////////////////////////////////////////////////////////////
 CSFML_GRAPHICS_API void sfRenderWindow_drawPrimitives(sfRenderWindow* renderWindow,
-                                                      const sfVertex* vertices, unsigned int vertexCount,
+                                                      const sfVertex* vertices, size_t vertexCount,
                                                       sfPrimitiveType type, const sfRenderStates* states);
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shape.h
+++ b/include/SFML/Graphics/Shape.h
@@ -34,10 +34,11 @@
 #include <SFML/Graphics/Transform.h>
 #include <SFML/Graphics/Types.h>
 #include <SFML/System/Vector2.h>
+#include <stddef.h>
 
 
-typedef unsigned int (*sfShapeGetPointCountCallback)(void*);        ///< Type of the callback used to get the number of points in a shape
-typedef sfVector2f (*sfShapeGetPointCallback)(unsigned int, void*); ///< Type of the callback used to get a point of a shape
+typedef size_t (*sfShapeGetPointCountCallback)(void*);        ///< Type of the callback used to get the number of points in a shape
+typedef sfVector2f (*sfShapeGetPointCallback)(size_t, void*); ///< Type of the callback used to get a point of a shape
 
 ////////////////////////////////////////////////////////////
 /// \brief Create a new shape
@@ -351,7 +352,7 @@ CSFML_GRAPHICS_API float sfShape_getOutlineThickness(const sfShape* shape);
 /// \return Number of points of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API unsigned int sfShape_getPointCount(const sfShape* shape);
+CSFML_GRAPHICS_API size_t sfShape_getPointCount(const sfShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get a point of a shape
@@ -364,7 +365,7 @@ CSFML_GRAPHICS_API unsigned int sfShape_getPointCount(const sfShape* shape);
 /// \return Index-th point of the shape
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfVector2f sfShape_getPoint(const sfShape* shape, unsigned int index);
+CSFML_GRAPHICS_API sfVector2f sfShape_getPoint(const sfShape* shape, size_t index);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the local bounding rectangle of a shape

--- a/include/SFML/Graphics/VertexArray.h
+++ b/include/SFML/Graphics/VertexArray.h
@@ -33,6 +33,7 @@
 #include <SFML/Graphics/Rect.h>
 #include <SFML/Graphics/Types.h>
 #include <SFML/Graphics/Vertex.h>
+#include <stddef.h>
 
 
 ////////////////////////////////////////////////////////////
@@ -69,7 +70,7 @@ CSFML_GRAPHICS_API void sfVertexArray_destroy(sfVertexArray* vertexArray);
 /// \return Number of vertices in the array
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API unsigned int sfVertexArray_getVertexCount(const sfVertexArray* vertexArray);
+CSFML_GRAPHICS_API size_t sfVertexArray_getVertexCount(const sfVertexArray* vertexArray);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get access to a vertex by its index
@@ -84,7 +85,7 @@ CSFML_GRAPHICS_API unsigned int sfVertexArray_getVertexCount(const sfVertexArray
 /// \return Pointer to the index-th vertex
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfVertex* sfVertexArray_getVertex(sfVertexArray* vertexArray, unsigned int index);
+CSFML_GRAPHICS_API sfVertex* sfVertexArray_getVertex(sfVertexArray* vertexArray, size_t index);
 
 ////////////////////////////////////////////////////////////
 /// \brief Clear a vertex array
@@ -112,7 +113,7 @@ CSFML_GRAPHICS_API void sfVertexArray_clear(sfVertexArray* vertexArray);
 /// \param vertexCount New size of the array (number of vertices)
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfVertexArray_resize(sfVertexArray* vertexArray, unsigned int vertexCount);
+CSFML_GRAPHICS_API void sfVertexArray_resize(sfVertexArray* vertexArray, size_t vertexCount);
 
 ////////////////////////////////////////////////////////////
 /// \brief Add a vertex to a vertex array array

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -80,7 +80,7 @@ sfSoundBuffer* sfSoundBuffer_createFromStream(sfInputStream* stream)
 
 
 ////////////////////////////////////////////////////////////
-sfSoundBuffer* sfSoundBuffer_createFromSamples(const sfInt16* samples, size_t sampleCount, unsigned int channelCount, unsigned int sampleRate)
+sfSoundBuffer* sfSoundBuffer_createFromSamples(const sfInt16* samples, sfUint64 sampleCount, unsigned int channelCount, unsigned int sampleRate)
 {
     sfSoundBuffer* buffer = new sfSoundBuffer;
 

--- a/src/SFML/Graphics/CircleShape.cpp
+++ b/src/SFML/Graphics/CircleShape.cpp
@@ -277,14 +277,14 @@ float sfCircleShape_getOutlineThickness(const sfCircleShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int sfCircleShape_getPointCount(const sfCircleShape* shape)
+size_t sfCircleShape_getPointCount(const sfCircleShape* shape)
 {
     CSFML_CALL_RETURN(shape, getPointCount(), 0);
 }
 
 
 ////////////////////////////////////////////////////////////
-sfVector2f sfCircleShape_getPoint(const sfCircleShape* shape, unsigned int index)
+sfVector2f sfCircleShape_getPoint(const sfCircleShape* shape, size_t index)
 {
     sfVector2f point = {0, 0};
     CSFML_CHECK_RETURN(shape, point);
@@ -312,7 +312,7 @@ float sfCircleShape_getRadius(const sfCircleShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-void sfCircleShape_setPointCount(sfCircleShape* shape, unsigned int count)
+void sfCircleShape_setPointCount(sfCircleShape* shape, size_t count)
 {
     CSFML_CALL(shape, setPointCount(count));
 }

--- a/src/SFML/Graphics/ConvexShape.cpp
+++ b/src/SFML/Graphics/ConvexShape.cpp
@@ -274,14 +274,14 @@ float sfConvexShape_getOutlineThickness(const sfConvexShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int sfConvexShape_getPointCount(const sfConvexShape* shape)
+size_t sfConvexShape_getPointCount(const sfConvexShape* shape)
 {
     CSFML_CALL_RETURN(shape, getPointCount(), 0);
 }
 
 
 ////////////////////////////////////////////////////////////
-sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape, unsigned int index)
+sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape, size_t index)
 {
     sfVector2f point = {0, 0};
     CSFML_CHECK_RETURN(shape, point);
@@ -295,14 +295,14 @@ sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape, unsigned int index
 
 
 ////////////////////////////////////////////////////////////
-void sfConvexShape_setPointCount(sfConvexShape* shape, unsigned int count)
+void sfConvexShape_setPointCount(sfConvexShape* shape, size_t count)
 {
     CSFML_CALL(shape, setPointCount(count));
 }
 
 
 ////////////////////////////////////////////////////////////
-void sfConvexShape_setPoint(sfConvexShape* shape, unsigned int index, sfVector2f point)
+void sfConvexShape_setPoint(sfConvexShape* shape, size_t index, sfVector2f point)
 {
     CSFML_CALL(shape, setPoint(index, sf::Vector2f(point.x, point.y)));
 }

--- a/src/SFML/Graphics/RectangleShape.cpp
+++ b/src/SFML/Graphics/RectangleShape.cpp
@@ -274,14 +274,14 @@ float sfRectangleShape_getOutlineThickness(const sfRectangleShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int sfRectangleShape_getPointCount(const sfRectangleShape* shape)
+size_t sfRectangleShape_getPointCount(const sfRectangleShape* shape)
 {
     CSFML_CALL_RETURN(shape, getPointCount(), 0);
 }
 
 
 ////////////////////////////////////////////////////////////
-sfVector2f sfRectangleShape_getPoint(const sfRectangleShape* shape, unsigned int index)
+sfVector2f sfRectangleShape_getPoint(const sfRectangleShape* shape, size_t index)
 {
     sfVector2f point = {0, 0};
     CSFML_CHECK_RETURN(shape, point);

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -218,7 +218,7 @@ void sfRenderTexture_drawVertexArray(sfRenderTexture* renderTexture, const sfVer
 
 ////////////////////////////////////////////////////////////
 void sfRenderTexture_drawPrimitives(sfRenderTexture* renderTexture,
-                                    const sfVertex* vertices, unsigned int vertexCount,
+                                    const sfVertex* vertices, size_t vertexCount,
                                     sfPrimitiveType type, const sfRenderStates* states)
 {
     CSFML_CALL(renderTexture, draw(reinterpret_cast<const sf::Vertex*>(vertices), vertexCount,

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -475,7 +475,7 @@ void sfRenderWindow_drawVertexArray(sfRenderWindow* renderWindow, const sfVertex
 
 ////////////////////////////////////////////////////////////
 void sfRenderWindow_drawPrimitives(sfRenderWindow* renderWindow,
-                                   const sfVertex* vertices, unsigned int vertexCount,
+                                   const sfVertex* vertices, size_t vertexCount,
                                    sfPrimitiveType type, const sfRenderStates* states)
 {
     CSFML_CALL(renderWindow, draw(reinterpret_cast<const sf::Vertex*>(vertices), vertexCount,

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -267,14 +267,14 @@ float sfShape_getOutlineThickness(const sfShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int sfShape_getPointCount(const sfShape* shape)
+size_t sfShape_getPointCount(const sfShape* shape)
 {
     CSFML_CALL_RETURN(shape, getPointCount(), 0);
 }
 
 
 ////////////////////////////////////////////////////////////
-sfVector2f sfShape_getPoint(const sfShape* shape, unsigned int index)
+sfVector2f sfShape_getPoint(const sfShape* shape, size_t index)
 {
     sfVector2f point = {0, 0};
     CSFML_CHECK_RETURN(shape, point);

--- a/src/SFML/Graphics/ShapeStruct.h
+++ b/src/SFML/Graphics/ShapeStruct.h
@@ -51,12 +51,12 @@ public :
     {
     }
 
-    virtual unsigned int getPointCount() const
+    virtual std::size_t getPointCount() const
     {
         return myGetPointCountCallback(myUserData);
     }
 
-    virtual sf::Vector2f getPoint(unsigned int index) const
+    virtual sf::Vector2f getPoint(std::size_t index) const
     {
         sfVector2f point = myGetPointCallback(index, myUserData);
         return sf::Vector2f(point.x, point.y);

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -54,14 +54,14 @@ void sfVertexArray_destroy(sfVertexArray* vertexArray)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int sfVertexArray_getVertexCount(const sfVertexArray* vertexArray)
+size_t sfVertexArray_getVertexCount(const sfVertexArray* vertexArray)
 {
     CSFML_CALL_RETURN(vertexArray, getVertexCount(), 0);
 }
 
 
 ////////////////////////////////////////////////////////////
-sfVertex* sfVertexArray_getVertex(sfVertexArray* vertexArray, unsigned int index)
+sfVertex* sfVertexArray_getVertex(sfVertexArray* vertexArray, size_t index)
 {
     CSFML_CHECK_RETURN(vertexArray, NULL);
 
@@ -78,7 +78,7 @@ void sfVertexArray_clear(sfVertexArray* vertexArray)
 
 
 ////////////////////////////////////////////////////////////
-void sfVertexArray_resize(sfVertexArray* vertexArray, unsigned int vertexCount)
+void sfVertexArray_resize(sfVertexArray* vertexArray, size_t vertexCount)
 {
     CSFML_CALL(vertexArray, resize(vertexCount));
 }


### PR DESCRIPTION
Count of objects and indices now use size_t in SFML. This pull request applies this change to CSFML.
It fixes compilation (ShapeImpl now correctly implements the pure virtual methods), and also correctly uses size_t in the other places.