### PR TITLE
Added missing sfSoundBufferRecorder_XXX methods

### DIFF
--- a/include/SFML/Audio/SoundBufferRecorder.h
+++ b/include/SFML/Audio/SoundBufferRecorder.h
@@ -101,5 +101,31 @@ CSFML_AUDIO_API unsigned int sfSoundBufferRecorder_getSampleRate(const sfSoundBu
 ////////////////////////////////////////////////////////////
 CSFML_AUDIO_API const sfSoundBuffer* sfSoundBufferRecorder_getBuffer(const sfSoundBufferRecorder* soundBufferRecorder);
 
+////////////////////////////////////////////////////////////
+/// \brief Set the audio capture device
+///
+/// This function sets the audio capture device to the device
+/// with the given name. It can be called on the fly (i.e:
+/// while recording). If you do so while recording and
+/// opening the device fails, it stops the recording.
+///
+/// \param soundBufferRecorder Sound buffer recorder object
+/// \param name                The name of the audio capture device
+///
+/// \return sfTrue, if it was able to set the requested device
+///
+////////////////////////////////////////////////////////////
+CSFML_AUDIO_API sfBool sfSoundBufferRecorder_setDevice(sfSoundBufferRecorder* soundBufferRecorder, const char* name);
+
+////////////////////////////////////////////////////////////
+/// \brief Get the name of the current audio capture device
+///
+/// \param soundBufferRecorder Sound buffer recorder object
+///
+/// \return The name of the current audio capture device
+///
+////////////////////////////////////////////////////////////
+CSFML_AUDIO_API const char* sfSoundBufferRecorder_getDevice(sfSoundBufferRecorder* soundBufferRecorder);
+
 
 #endif // SFML_SOUNDBUFFERRECORDER_H

--- a/include/SFML/Audio/SoundRecorder.h
+++ b/include/SFML/Audio/SoundRecorder.h
@@ -129,7 +129,7 @@ CSFML_AUDIO_API sfBool sfSoundRecorder_isAvailable(void);
 /// The default processing interval is 100 ms.
 ///
 /// \param soundRecorder Sound recorder object
-/// \param interval Processing interval
+/// \param interval      Processing interval
 ///
 ////////////////////////////////////////////////////////////
 CSFML_AUDIO_API void sfSoundRecorder_setProcessingInterval(sfSoundRecorder* soundRecorder, sfTime interval);
@@ -168,7 +168,7 @@ CSFML_AUDIO_API const char* sfSoundRecorder_getDefaultDevice();
 /// opening the device fails, it stops the recording.
 ///
 /// \param soundRecorder Sound recorder object
-/// \param The name of the audio capture device
+/// \param name          The name of the audio capture device
 ///
 /// \return sfTrue, if it was able to set the requested device
 ///

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -74,3 +74,19 @@ const sfSoundBuffer* sfSoundBufferRecorder_getBuffer(const sfSoundBufferRecorder
 
     return &soundBufferRecorder->SoundBuffer;
 }
+
+////////////////////////////////////////////////////////////
+sfBool sfSoundBufferRecorder_setDevice(sfSoundBufferRecorder* soundBufferRecorder, const char* name)
+{
+    CSFML_CALL_RETURN(soundBufferRecorder, setDevice(name), sfFalse);
+}
+
+////////////////////////////////////////////////////////////
+const char* sfSoundBufferRecorder_getDevice(sfSoundBufferRecorder* soundBufferRecorder)
+{
+    CSFML_CHECK_RETURN(soundRecorder, NULL);
+
+    soundBufferRecorder->DeviceName = soundBufferRecorder->This.getDevice();
+
+    return soundBufferRecorder->DeviceName.c_str();
+}

--- a/src/SFML/Audio/SoundBufferRecorderStruct.h
+++ b/src/SFML/Audio/SoundBufferRecorderStruct.h
@@ -39,6 +39,7 @@ struct sfSoundBufferRecorder
 {
     sf::SoundBufferRecorder This;
     mutable sfSoundBuffer   SoundBuffer;
+    std::string             DeviceName;
 };
 
 


### PR DESCRIPTION
Fixes #83. This PR only adds 2 new methods to set/get the audio device. I left out the processing interval as that is a protected method (only accessible when inheriting ```sf::SoundRecorder``` and since ```sfSoundBufferRecorder``` is already a specialized subclass it doesn't provide access to any of the other protected methods (callbacks).