### PR TITLE
Bump version number in Config.h

### DIFF
--- a/include/SFML/Config.h
+++ b/include/SFML/Config.h
@@ -30,7 +30,7 @@
 // Define the CSFML version
 ////////////////////////////////////////////////////////////
 #define CSFML_VERSION_MAJOR 2
-#define CSFML_VERSION_MINOR 3
+#define CSFML_VERSION_MINOR 4
 #define CSFML_VERSION_PATCH 0
 
 


### PR DESCRIPTION
The version in CMakeLists.txt was bumped, but not this one. Maybe someone else want to keep those two files in sink by means of auto-configuration using CMake, but in the meantime here's a quick fix. ;-)