### PR TITLE
Have sfContext_setActive return sfBool instead of void

### DIFF
--- a/include/SFML/Window/Context.h
+++ b/include/SFML/Window/Context.h
@@ -56,8 +56,10 @@ CSFML_WINDOW_API void sfContext_destroy(sfContext* context);
 /// \param context Context object
 /// \param active  sfTrue to activate, sfFalse to deactivate
 ///
+/// \return True on success, false on failure
+///
 ////////////////////////////////////////////////////////////
-CSFML_WINDOW_API void sfContext_setActive(sfContext* context, sfBool active);
+CSFML_WINDOW_API sfBool sfContext_setActive(sfContext* context, sfBool active);
 
 
 #endif // SFML_CONTEXT_H

--- a/include/SFML/Window/Context.h
+++ b/include/SFML/Window/Context.h
@@ -56,7 +56,7 @@ CSFML_WINDOW_API void sfContext_destroy(sfContext* context);
 /// \param context Context object
 /// \param active  sfTrue to activate, sfFalse to deactivate
 ///
-/// \return True on success, false on failure
+/// \return sfTrue on success, sfFalse on failure
 ///
 ////////////////////////////////////////////////////////////
 CSFML_WINDOW_API sfBool sfContext_setActive(sfContext* context, sfBool active);

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -45,7 +45,7 @@ void sfContext_destroy(sfContext* context)
 
 
 ////////////////////////////////////////////////////////////
-void sfContext_setActive(sfContext* context, sfBool active)
+sfBool sfContext_setActive(sfContext* context, sfBool active)
 {
-    CSFML_CALL(context, setActive(active == sfTrue));
+    CSFML_CALL_RETURN(context, setActive(active == sfTrue), false)
 }


### PR DESCRIPTION
Return the result of sf::Context::setActive instead of discarding it.