### PR TITLE
Deduplicate code for sfContextSettings

### DIFF
--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -38,6 +38,7 @@
 #include <SFML/Graphics/ConvertRenderStates.hpp>
 #include <SFML/Window/Touch.hpp>
 #include <SFML/Internal.h>
+#include <SFML/Window/ContextSettingsInternal.h>
 #include <SFML/ConvertEvent.h>
 
 
@@ -51,12 +52,7 @@ sfRenderWindow* sfRenderWindow_create(sfVideoMode mode, const char* title, sfUin
     sf::ContextSettings params;
     if (settings)
     {
-        params.depthBits         = settings->depthBits;
-        params.stencilBits       = settings->stencilBits;
-        params.antialiasingLevel = settings->antialiasingLevel;
-        params.majorVersion      = settings->majorVersion;
-        params.minorVersion      = settings->minorVersion;
-        params.attributeFlags    = settings->attributeFlags;
+        priv::sfContextSettings_writeToCpp(*settings, params);
     }
 
     // Create the window
@@ -78,12 +74,7 @@ sfRenderWindow* sfRenderWindow_createUnicode(sfVideoMode mode, const sfUint32* t
     sf::ContextSettings params;
     if (settings)
     {
-        params.depthBits         = settings->depthBits;
-        params.stencilBits       = settings->stencilBits;
-        params.antialiasingLevel = settings->antialiasingLevel;
-        params.majorVersion      = settings->majorVersion;
-        params.minorVersion      = settings->minorVersion;
-        params.attributeFlags    = settings->attributeFlags;
+        priv::sfContextSettings_writeToCpp(*settings, params);
     }
 
     // Create the window
@@ -103,12 +94,7 @@ sfRenderWindow* sfRenderWindow_createFromHandle(sfWindowHandle handle, const sfC
     sf::ContextSettings params;
     if (settings)
     {
-        params.depthBits         = settings->depthBits;
-        params.stencilBits       = settings->stencilBits;
-        params.antialiasingLevel = settings->antialiasingLevel;
-        params.majorVersion      = settings->majorVersion;
-        params.minorVersion      = settings->minorVersion;
-        params.attributeFlags    = settings->attributeFlags;
+        priv::sfContextSettings_writeToCpp(*settings, params);
     }
 
     // Create the window
@@ -145,16 +131,11 @@ sfBool sfRenderWindow_isOpen(const sfRenderWindow* renderWindow)
 ////////////////////////////////////////////////////////////
 sfContextSettings sfRenderWindow_getSettings(const sfRenderWindow* renderWindow)
 {
-    sfContextSettings settings = {0, 0, 0, 2, 0};
+    sfContextSettings settings = priv::sfContextSettings_null();
     CSFML_CHECK_RETURN(renderWindow, settings);
 
     const sf::ContextSettings& params = renderWindow->This.getSettings();
-    settings.depthBits         = params.depthBits;
-    settings.stencilBits       = params.stencilBits;
-    settings.antialiasingLevel = params.antialiasingLevel;
-    settings.majorVersion      = params.majorVersion;
-    settings.minorVersion      = params.minorVersion;
-    settings.attributeFlags    = params.attributeFlags;
+    priv::sfContextSettings_readFromCpp(params, settings);
 
     return settings;
 }

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC
     ${INCROOT}/Export.h
     ${SRCROOT}/Context.cpp
     ${SRCROOT}/ContextSettingsInternal.cpp
+    ${SRCROOT}/ContextSettingsInternal.h
     ${SRCROOT}/ContextStruct.h
     ${INCROOT}/Context.h
     ${INCROOT}/Event.h

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRCROOT ${CMAKE_SOURCE_DIR}/src/SFML/Window)
 set(SRC
     ${INCROOT}/Export.h
     ${SRCROOT}/Context.cpp
+    ${SRCROOT}/ContextSettingsInternal.cpp
     ${SRCROOT}/ContextStruct.h
     ${INCROOT}/Context.h
     ${INCROOT}/Event.h

--- a/src/SFML/Window/ContextSettingsInternal.cpp
+++ b/src/SFML/Window/ContextSettingsInternal.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////
 //
 // SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+// Copyright (C) 2007-2016 Laurent Gomila (laurent@sfml-dev.org)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -25,40 +25,41 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Window/Context.h>
-#include <SFML/Window/ContextStruct.h>
-#include <SFML/Internal.h>
 #include <SFML/Window/ContextSettingsInternal.h>
 
 
-////////////////////////////////////////////////////////////
-sfContext* sfContext_create(void)
+namespace priv
 {
-    return new sfContext;
-}
-
-
 ////////////////////////////////////////////////////////////
-void sfContext_destroy(sfContext* context)
+sfContextSettings sfContextSettings_null()
 {
-    delete context;
-}
-
-
-////////////////////////////////////////////////////////////
-sfBool sfContext_setActive(sfContext* context, sfBool active)
-{
-    CSFML_CALL_RETURN(context, setActive(active == sfTrue), false)
-}
-
-////////////////////////////////////////////////////////////
-sfContextSettings sfContext_getSettings(const sfContext* context)
-{
-    sfContextSettings settings = priv::sfContextSettings_null();
-    CSFML_CHECK_RETURN(context, settings);
-
-    const sf::ContextSettings& params = context->This.getSettings();
-    priv::sfContextSettings_readFromCpp(params, settings);
+    sfContextSettings settings = {0, 0, 0, 0, 0, 0};
 
     return settings;
 }
+
+
+////////////////////////////////////////////////////////////
+void sfContextSettings_readFromCpp(const sf::ContextSettings& from, sfContextSettings& to)
+{
+    to.depthBits         = from.depthBits;
+    to.stencilBits       = from.stencilBits;
+    to.antialiasingLevel = from.antialiasingLevel;
+    to.majorVersion      = from.majorVersion;
+    to.minorVersion      = from.minorVersion;
+    to.attributeFlags    = from.attributeFlags;
+}
+
+
+////////////////////////////////////////////////////////////
+void sfContextSettings_writeToCpp(const sfContextSettings& from, sf::ContextSettings& to)
+{
+    to.depthBits         = from.depthBits;
+    to.stencilBits       = from.stencilBits;
+    to.antialiasingLevel = from.antialiasingLevel;
+    to.majorVersion      = from.majorVersion;
+    to.minorVersion      = from.minorVersion;
+    to.attributeFlags    = from.attributeFlags;
+}
+
+} // namespace priv

--- a/src/SFML/Window/ContextSettingsInternal.h
+++ b/src/SFML/Window/ContextSettingsInternal.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////
 //
 // SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+// Copyright (C) 2007-2016 Laurent Gomila (laurent@sfml-dev.org)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -22,43 +22,31 @@
 //
 ////////////////////////////////////////////////////////////
 
+#ifndef SFML_CONTEXTSETTINGSINTERNAL_H
+#define SFML_CONTEXTSETTINGSINTERNAL_H
+
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Window/Context.h>
-#include <SFML/Window/ContextStruct.h>
-#include <SFML/Internal.h>
-#include <SFML/Window/ContextSettingsInternal.h>
+#include <SFML/Window.h>
+#include <SFML/Window.hpp>
 
-
-////////////////////////////////////////////////////////////
-sfContext* sfContext_create(void)
+namespace priv
 {
-    return new sfContext;
+    ////////////////////////////////////////////////////////////
+    // Create a "null" sfContextSettings that's returned in case of an error.
+    ////////////////////////////////////////////////////////////
+    sfContextSettings sfContextSettings_null();
+
+    ////////////////////////////////////////////////////////////
+    // Read the data of an sf::ContextSettings into an sfContextSettings
+    ////////////////////////////////////////////////////////////
+    void sfContextSettings_readFromCpp(const sf::ContextSettings& from, sfContextSettings& to);
+
+    ////////////////////////////////////////////////////////////
+    // Read the data of an sf::ContextSettings into an sfContextSettings
+    ////////////////////////////////////////////////////////////
+    void sfContextSettings_writeToCpp(const sfContextSettings& from, sf::ContextSettings& to);
 }
 
-
-////////////////////////////////////////////////////////////
-void sfContext_destroy(sfContext* context)
-{
-    delete context;
-}
-
-
-////////////////////////////////////////////////////////////
-sfBool sfContext_setActive(sfContext* context, sfBool active)
-{
-    CSFML_CALL_RETURN(context, setActive(active == sfTrue), false)
-}
-
-////////////////////////////////////////////////////////////
-sfContextSettings sfContext_getSettings(const sfContext* context)
-{
-    sfContextSettings settings = priv::sfContextSettings_null();
-    CSFML_CHECK_RETURN(context, settings);
-
-    const sf::ContextSettings& params = context->This.getSettings();
-    priv::sfContextSettings_readFromCpp(params, settings);
-
-    return settings;
-}
+#endif // SFML_CONTEXTSETTINGSINTERNAL_H

--- a/src/SFML/Window/ContextSettingsInternal.h
+++ b/src/SFML/Window/ContextSettingsInternal.h
@@ -44,7 +44,7 @@ namespace priv
     void sfContextSettings_readFromCpp(const sf::ContextSettings& from, sfContextSettings& to);
 
     ////////////////////////////////////////////////////////////
-    // Read the data of an sf::ContextSettings into an sfContextSettings
+    // Write the data of an sfContextSettings into an sf::ContextSettings
     ////////////////////////////////////////////////////////////
     void sfContextSettings_writeToCpp(const sfContextSettings& from, sf::ContextSettings& to);
 }

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Window/Window.h>
 #include <SFML/Window/WindowStruct.h>
 #include <SFML/Internal.h>
+#include <SFML/Window/ContextSettingsInternal.h>
 #include <SFML/ConvertEvent.h>
 
 
@@ -41,12 +42,7 @@ sfWindow* sfWindow_create(sfVideoMode mode, const char* title, sfUint32 style, c
     sf::ContextSettings params;
     if (settings)
     {
-        params.depthBits         = settings->depthBits;
-        params.stencilBits       = settings->stencilBits;
-        params.antialiasingLevel = settings->antialiasingLevel;
-        params.majorVersion      = settings->majorVersion;
-        params.minorVersion      = settings->minorVersion;
-        params.attributeFlags    = settings->attributeFlags;
+        priv::sfContextSettings_writeToCpp(*settings, params);
     }
 
     // Create the window
@@ -66,12 +62,7 @@ sfWindow* sfWindow_createUnicode(sfVideoMode mode, const sfUint32* title, sfUint
     sf::ContextSettings params;
     if (settings)
     {
-        params.depthBits         = settings->depthBits;
-        params.stencilBits       = settings->stencilBits;
-        params.antialiasingLevel = settings->antialiasingLevel;
-        params.majorVersion      = settings->majorVersion;
-        params.minorVersion      = settings->minorVersion;
-        params.attributeFlags    = settings->attributeFlags;
+        priv::sfContextSettings_writeToCpp(*settings, params);
     }
 
     // Create the window
@@ -89,12 +80,7 @@ sfWindow* sfWindow_createFromHandle(sfWindowHandle handle, const sfContextSettin
     sf::ContextSettings params;
     if (settings)
     {
-        params.depthBits         = settings->depthBits;
-        params.stencilBits       = settings->stencilBits;
-        params.antialiasingLevel = settings->antialiasingLevel;
-        params.majorVersion      = settings->majorVersion;
-        params.minorVersion      = settings->minorVersion;
-        params.attributeFlags    = settings->attributeFlags;
+        priv::sfContextSettings_writeToCpp(*settings, params);
     }
 
     // Create the window
@@ -128,16 +114,11 @@ sfBool sfWindow_isOpen(const sfWindow* window)
 ////////////////////////////////////////////////////////////
 sfContextSettings sfWindow_getSettings(const sfWindow* window)
 {
-    sfContextSettings settings = {0, 0, 0, 0, 0};
+    sfContextSettings settings = priv::sfContextSettings_null();
     CSFML_CHECK_RETURN(window, settings);
 
     const sf::ContextSettings& params = window->This.getSettings();
-    settings.depthBits         = params.depthBits;
-    settings.stencilBits       = params.stencilBits;
-    settings.antialiasingLevel = params.antialiasingLevel;
-    settings.majorVersion      = params.majorVersion;
-    settings.minorVersion      = params.minorVersion;
-    settings.attributeFlags    = params.attributeFlags;
+    priv::sfContextSettings_readFromCpp(params, settings);
 
     return settings;
 }


### PR DESCRIPTION
This increases maintainability, as fewer code has to be updated
when adding a field to sfContextSettings.

Ref #115 