### PR TITLE
sfText_getLineSpacing is not properly declared in Text.h

### DIFF
--- a/include/SFML/Graphics/Text.h
+++ b/include/SFML/Graphics/Text.h
@@ -445,7 +445,7 @@ CSFML_GRAPHICS_API float sfText_getLetterSpacing(const sfText* text);
 /// \see sfText_setLineSpacing
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API float getLineSpacing(const sfText* text);
+CSFML_GRAPHICS_API float sfText_getLineSpacing(const sfText* text);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the style of a text


### PR DESCRIPTION
Corrected. Already properly named in Text.cpp