### PR TITLE
Implement sfTexture_updateFromTexture

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -182,6 +182,15 @@ void sfTexture_updateFromPixels(sfTexture* texture, const sfUint8* pixels, unsig
 
 
 ////////////////////////////////////////////////////////////
+void sfTexture_updateFromTexture(sfTexture* destination, const sfTexture* texture, unsigned int x, unsigned int y);
+{
+    CSFML_CHECK(texture);
+
+    CSFML_CALL_PTR(destination, update(texture->This, x, y));
+}
+
+
+////////////////////////////////////////////////////////////
 void sfTexture_updateFromImage(sfTexture* texture, const sfImage* image, unsigned int x, unsigned int y)
 {
     CSFML_CHECK(image);


### PR DESCRIPTION
Method was declared, but not implemented. Also corrects an EntryPointNotFound exception in SFML.NET

Fixes #141 