### PR TITLE
Add RenderTarget functions for VertexBuffer

### DIFF
--- a/include/SFML/Graphics/RenderTexture.h
+++ b/include/SFML/Graphics/RenderTexture.h
@@ -222,6 +222,7 @@ CSFML_GRAPHICS_API void sfRenderTexture_drawConvexShape(sfRenderTexture* renderT
 CSFML_GRAPHICS_API void sfRenderTexture_drawRectangleShape(sfRenderTexture* renderTexture, const sfRectangleShape* object, const sfRenderStates* states);
 CSFML_GRAPHICS_API void sfRenderTexture_drawVertexArray(sfRenderTexture* renderTexture, const sfVertexArray* object, const sfRenderStates* states);
 CSFML_GRAPHICS_API void sfRenderTexture_drawVertexBuffer(sfRenderTexture* renderTexture, const sfVertexBuffer* object, const sfRenderStates* states);
+CSFML_GRAPHICS_API void sfRenderTexture_drawVertexBufferRange(sfRenderTexture* renderTexture, const sfVertexBuffer* object, size_t firstVertex, size_t vertexCount, const sfRenderStates* states);
 
 ////////////////////////////////////////////////////////////
 /// \brief Draw primitives defined by an array of vertices to a render texture

--- a/include/SFML/Graphics/RenderWindow.h
+++ b/include/SFML/Graphics/RenderWindow.h
@@ -465,6 +465,7 @@ CSFML_GRAPHICS_API void sfRenderWindow_drawConvexShape(sfRenderWindow* renderWin
 CSFML_GRAPHICS_API void sfRenderWindow_drawRectangleShape(sfRenderWindow* renderWindow, const sfRectangleShape* object, const sfRenderStates* states);
 CSFML_GRAPHICS_API void sfRenderWindow_drawVertexArray(sfRenderWindow* renderWindow, const sfVertexArray* object, const sfRenderStates* states);
 CSFML_GRAPHICS_API void sfRenderWindow_drawVertexBuffer(sfRenderWindow* renderWindow, const sfVertexBuffer* object, const sfRenderStates* states);
+CSFML_GRAPHICS_API void sfRenderWindow_drawVertexBufferRange(sfRenderWindow* renderWindow, const sfVertexBuffer* object, size_t firstVertex, size_t vertexCount, const sfRenderStates* states);
 
 ////////////////////////////////////////////////////////////
 /// \brief Draw primitives defined by an array of vertices to a render window

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -242,6 +242,14 @@ void sfRenderTexture_drawVertexBuffer(sfRenderTexture* renderTexture, const sfVe
     CSFML_CHECK(object);
     CSFML_CALL(renderTexture, draw(object->This, convertRenderStates(states)));
 }
+void sfRenderTexture_drawVertexBufferRange(sfRenderTexture* renderTexture,
+                                          const sfVertexBuffer* object,
+                                          size_t firstVertex, size_t vertexCount,
+                                          const sfRenderStates* states)
+{
+        CSFML_CHECK(object);
+        CSFML_CALL(renderTexture, draw(object->This, firstVertex, vertexCount, convertRenderStates(states)));
+}
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -475,6 +475,14 @@ void sfRenderWindow_drawVertexBuffer(sfRenderWindow* renderWindow, const sfVerte
     CSFML_CHECK(object);
     CSFML_CALL(renderWindow, draw(object->This, convertRenderStates(states)));
 }
+void sfRenderWindow_drawVertexBufferRange(sfRenderWindow* renderWindow,
+                                          const sfVertexBuffer* object,
+                                          size_t firstVertex, size_t vertexCount,
+                                          const sfRenderStates* states)
+{
+        CSFML_CHECK(object);
+        CSFML_CALL(renderWindow, draw(object->This, firstVertex, vertexCount, convertRenderStates(states)));
+}
 
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
In the SFML library, `sf::RenderTarget` exposes a method 

```c++
draw(const VertexBuffer &vertexBuffer, 
      std::size_t firstVertex,
      std::size_t vertexCount,
      const RenderStates &states=RenderStates::Default)
```

I think it would be useful to expose it in CSFML, so I added the `drawVertexBufferRange` functions to RenderWindow and RenderTexture.
Please let me know if there is something I haven't considered and/or done badly in the implementation.


