### PR TITLE
Add GitHub actions for Windows, Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.platform.name }} ${{ matrix.config.name }}
+    runs-on: ${{ matrix.platform.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: Windows VS2017, os: windows-2016   }
+        - { name: Windows VS2019, os: windows-latest }
+        - { name: Linux GCC,      os: ubuntu-latest  }
+        - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: MacOS XCode,    os: macos-latest,  flags: -DSFML_BUILD_FRAMEWORKS=FALSE, prefix: sudo }
+    steps:
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev
+
+    - name: Checkout SFML
+      uses: actions/checkout@v2
+      with:
+        repository: SFML/SFML
+        ref: 2.5.1
+        path: SFML
+
+    - name: Configure SFML CMake
+      shell: bash
+      run: cmake -S $GITHUB_WORKSPACE/SFML -B $GITHUB_WORKSPACE/SFML/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/SFML/install -DBUILD_SHARED_LIBS=TRUE -DSFML_BUILD_EXAMPLES=FALSE -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}}
+    
+    - name: Build SFML
+      shell: bash
+      run: ${{matrix.platform.prefix}} cmake --build $GITHUB_WORKSPACE/SFML/build --config Release --target install
+
+    - name: Checkout CSFML
+      uses: actions/checkout@v2
+      with:
+        path: CSFML
+
+    - name: Configure CSFML CMake
+      shell: bash
+      run: cmake -S $GITHUB_WORKSPACE/CSFML -B $GITHUB_WORKSPACE/CSFML/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/CSFML/install -DBUILD_SHARED_LIBS=TRUE -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}}
+
+    - name: Build CSFML
+      shell: bash
+      run: cmake --build $GITHUB_WORKSPACE/CSFML/build --config Release --target install


### PR DESCRIPTION
With Travis CI essentially "gone" and having GitHub Actions nicely integrated in GitHub, I think it makes sense to go ahead with GitHub Actions as our CI pipeline.

This is first step in getting, Windows, Linux and macOS builds just up and running.

At a later point, I'd like to add the whole NuGet packing and publishing as well, so we can publish a new NuGet version with a press of a button or similar, this however needs some more testing first and this time I want to make sure we can bundle Linux, Windows and macOS.