### PR TITLE
Make sure CallbackStream doesn't get destroyed before the Music

### DIFF
--- a/src/SFML/Audio/MusicStruct.h
+++ b/src/SFML/Audio/MusicStruct.h
@@ -37,8 +37,8 @@
 ////////////////////////////////////////////////////////////
 struct sfMusic
 {
-    sf::Music This;
     CallbackStream Stream;
+    sf::Music This;
 };
 
 


### PR DESCRIPTION
Music's destructor call's stop(), which in turn calls onSeek.
For CSFML, this requires the CallbackStream to stay alive until that point.

In C++, destructors for fields are called in reverse declaration order.
We swap the order of the fields, putting the Music after the
CallbackStream, so it gets destroyed before it.