### PR TITLE
Ensure public header path gets propagated to downstream targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,6 @@ project(CSFML VERSION 2.5.1)
 # include the configuration file
 include(${PROJECT_SOURCE_DIR}/cmake/Config.cmake)
 
-# add the CSFML header path
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
 # add an option for choosing the build type (shared or static)
 csfml_set_option(BUILD_SHARED_LIBS TRUE BOOL "TRUE to build CSFML as shared libraries, FALSE to build it as static libraries")
 

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -12,6 +12,9 @@ macro(csfml_add_library target)
     # create the target
     add_library(${target} ${THIS_SOURCES})
 
+    # add the CSFML header path
+    target_include_directories(${target} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
     # define the export symbol of the module
     string(REPLACE "-" "_" NAME_UPPER "${target}")
     string(TOUPPER "${NAME_UPPER}" NAME_UPPER)


### PR DESCRIPTION
This ensures that those including CSFML via `add_subdirectory` get the correct header path when linking to CSFML targets.