### PR TITLE
Add pkg-config files, optionally installed by CMake on Linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,28 @@ if(CSFML_BUILD_DOC)
     add_subdirectory(doc)
 endif()
 
+# on Linux and BSD-like OS, install pkg-config files by default
+set(CSFML_INSTALL_PKGCONFIG_DEFAULT FALSE)
+
+if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
+    set(CSFML_INSTALL_PKGCONFIG_DEFAULT TRUE)
+endif()
+
+csfml_set_option(CSFML_INSTALL_PKGCONFIG_FILES ${CSFML_INSTALL_PKGCONFIG_DEFAULT} BOOL "TRUE to automatically install pkg-config files so other projects can find SFML")
+
+if(CSFML_INSTALL_PKGCONFIG_FILES)
+    csfml_set_option(CSFML_PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/${CSFML_PKGCONFIG_DIR}" PATH "Install directory for CSFML's pkg-config .pc files")
+
+    foreach(csfml_module IN ITEMS all system window graphics audio network)
+        configure_file(
+            "tools/pkg-config/csfml-${csfml_module}.pc.in"
+            "tools/pkg-config/csfml-${csfml_module}.pc"
+            @ONLY)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tools/pkg-config/csfml-${csfml_module}.pc"
+            DESTINATION "${CSFML_PKGCONFIG_INSTALL_PREFIX}")
+    endforeach()
+endif()
+
 # setup the install rules
 install(DIRECTORY include
         DESTINATION .

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -32,6 +32,14 @@ else()
     return()
 endif()
 
+# set pkgconfig install directory
+# this could be e.g. macports on mac or msys2 on windows etc.
+set(CSFML_PKGCONFIG_DIR "/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+if(SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
+    set(CSFML_PKGCONFIG_DIR "/libdata/pkgconfig")
+endif()
+
 # detect the compiler and its version
 # Note: The detection is order is important because:
 # - Visual Studio can both use MSVC and Clang

--- a/tools/pkg-config/csfml-all.pc.in
+++ b/tools/pkg-config/csfml-all.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: CSFML-all
+Description: The Simple and Fast Multimedia Library for C, all modules.
+URL: https://www.sfml-dev.org
+Version: @PROJECT_VERSION@
+Requires: csfml-system, csfml-window, csfml-graphics, csfml-audio, csfml-network

--- a/tools/pkg-config/csfml-audio.pc.in
+++ b/tools/pkg-config/csfml-audio.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: CSFML-audio
+Description: The Simple and Fast Multimedia Library for C, audio module.
+URL: https://www.sfml-dev.org
+Version: @PROJECT_VERSION@
+Requires: csfml-system
+Requires.private: sfml-audio
+Libs: -L${libdir} -lcsfml-audio
+Cflags: -I${includedir}

--- a/tools/pkg-config/csfml-graphics.pc.in
+++ b/tools/pkg-config/csfml-graphics.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: CSFML-graphics
+Description: The Simple and Fast Multimedia Library for C, graphics module.
+URL: https://www.sfml-dev.org
+Version: @PROJECT_VERSION@
+Requires: csfml-window, csfml-system
+Requires.private: sfml-graphics
+Libs: -L${libdir} -lcsfml-graphics
+Cflags: -I${includedir}

--- a/tools/pkg-config/csfml-network.pc.in
+++ b/tools/pkg-config/csfml-network.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: CSFML-network
+Description: The Simple and Fast Multimedia Library for C, network module.
+URL: https://www.sfml-dev.org
+Version: @PROJECT_VERSION@
+Requires: csfml-system
+Requires.private: sfml-network
+Libs: -L${libdir} -lcsfml-network
+Cflags: -I${includedir}

--- a/tools/pkg-config/csfml-system.pc.in
+++ b/tools/pkg-config/csfml-system.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: CSFML-system
+Description: The Simple and Fast Multimedia Library for C, system module.
+URL: https://www.sfml-dev.org
+Version: @PROJECT_VERSION@
+Requires.private: sfml-system
+Libs: -L${libdir} -lcsfml-system
+Cflags: -I${includedir}

--- a/tools/pkg-config/csfml-window.pc.in
+++ b/tools/pkg-config/csfml-window.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: CSFML-window
+Description: The Simple and Fast Multimedia Library for C, window module.
+URL: https://www.sfml-dev.org
+Version: @PROJECT_VERSION@
+Requires: csfml-system
+Requires.private: sfml-window
+Libs: -L${libdir} -lcsfml-window
+Cflags: -I${includedir}


### PR DESCRIPTION
The modules provided are:

  - csfml-system
  - csfml-graphics
  - csfml-window
  - csfml-audio
  - csfml-network
  - csfml-all (depends on all the above modules)

They are installed to the standard location for pkg-config files on Linux.

This is adapted from SFML own pkg-config files.