### PR TITLE
Require SFML 2.6

### DIFF
--- a/src/SFML/CMakeLists.txt
+++ b/src/SFML/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CSFML_LINK_SFML_STATICALLY)
     set(SFML_STATIC_LIBRARIES TRUE)
     add_definitions(-DSFML_STATIC)
 endif()
-find_package(SFML 2.5 COMPONENTS network graphics audio REQUIRED)
+find_package(SFML 2.6 COMPONENTS network graphics audio REQUIRED)
 
 # add the modules subdirectories
 add_subdirectory(System)


### PR DESCRIPTION
It is technically already the case since commits e606b52c39516d0c29e62bad1dd851a929b9ab95 and 7d2ebaf265140ee6d2ff0eb469ec36118d3cccc8