### PR TITLE
Implement fetching bold kerning

### DIFF
--- a/include/SFML/Graphics/Font.h
+++ b/include/SFML/Graphics/Font.h
@@ -113,6 +113,19 @@ CSFML_GRAPHICS_API sfGlyph sfFont_getGlyph(const sfFont* font, sfUint32 codePoin
 CSFML_GRAPHICS_API float sfFont_getKerning(const sfFont* font, sfUint32 first, sfUint32 second, unsigned int characterSize);
 
 ////////////////////////////////////////////////////////////
+/// \brief Get the bold kerning value corresponding to a given pair of characters in a font
+///
+/// \param font          Source font
+/// \param first         Unicode code point of the first character
+/// \param second        Unicode code point of the second character
+/// \param characterSize Character size, in pixels
+///
+/// \return Kerning offset, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API float sfFont_getBoldKerning(const sfFont* font, sfUint32 first, sfUint32 second, unsigned int characterSize);
+
+////////////////////////////////////////////////////////////
 /// \brief Get the line spacing value
 ///
 /// \param font          Source font

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -122,6 +122,13 @@ float sfFont_getKerning(const sfFont* font, sfUint32 first, sfUint32 second, uns
 
 
 ////////////////////////////////////////////////////////////
+float sfFont_getBoldKerning(const sfFont* font, sfUint32 first, sfUint32 second, unsigned int characterSize)
+{
+    CSFML_CALL_RETURN(font, getKerning(first, second, characterSize, true), 0);
+}
+
+
+////////////////////////////////////////////////////////////
 float sfFont_getLineSpacing(const sfFont* font, unsigned int characterSize)
 {
     CSFML_CALL_RETURN(font, getLineSpacing(characterSize), 0);


### PR DESCRIPTION
C doesn't have function overloading, so I had to resort to function name signature changes to resemble overloading. I think this is an ok way to do this