### PR TITLE
Implement `sf::Image::saveToMemory`

### DIFF
--- a/include/SFML/Graphics/Image.h
+++ b/include/SFML/Graphics/Image.h
@@ -156,8 +156,33 @@ CSFML_GRAPHICS_API void sfImage_destroy(sfImage* image);
 ///
 /// \return sfTrue if saving was successful
 ///
+/// \see sfImage_saveToMemory
+///
 ////////////////////////////////////////////////////////////
 CSFML_GRAPHICS_API sfBool sfImage_saveToFile(const sfImage* image, const char* filename);
+
+////////////////////////////////////////////////////////////
+/// \brief Save the image to a buffer in memory
+///
+/// The format of the image must be specified.
+/// The supported image formats are bmp, png, tga and jpg.
+/// This function fails if the image is empty, or if
+/// the format was invalid.
+///
+/// The array pointed to by \p buffer must be freed to prevent
+/// a memory leak.
+///
+/// \param image  Image object
+/// \param buffer Address of buffer to fill with encoded data
+/// \param size   Size of buffer
+/// \param format Encoding format to use
+///
+/// \return True if saving was successful
+///
+/// \see sfImage_saveToFile
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API sfBool sfImage_saveToMemory(const sfImage* image, unsigned char** buffer, size_t* size, const char* format);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the size of an image

--- a/include/SFML/Graphics/Image.h
+++ b/include/SFML/Graphics/Image.h
@@ -169,9 +169,6 @@ CSFML_GRAPHICS_API sfBool sfImage_saveToFile(const sfImage* image, const char* f
 /// This function fails if the image is empty, or if
 /// the format was invalid.
 ///
-/// The array pointed to by \p buffer must be freed to prevent
-/// a memory leak.
-///
 /// \param image  Image object
 /// \param buffer Address of buffer to fill with encoded data
 /// \param size   Size of buffer

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -30,6 +30,9 @@
 #include <SFML/Internal.h>
 #include <SFML/CallbackStream.h>
 
+#include <cstdlib>
+#include <cstring>
+
 ////////////////////////////////////////////////////////////
 sfImage* sfImage_create(unsigned int width, unsigned int height)
 {
@@ -128,6 +131,28 @@ void sfImage_destroy(sfImage* image)
 sfBool sfImage_saveToFile(const sfImage* image, const char* filename)
 {
     CSFML_CALL_RETURN(image, saveToFile(filename), sfFalse);
+}
+
+
+////////////////////////////////////////////////////////////
+sfBool sfImage_saveToMemory(const sfImage* image, unsigned char** buffer, size_t* size, const char* format)
+{
+    CSFML_CHECK_RETURN(image, sfFalse);
+
+    std::vector<sf::Uint8> output;
+    if (image->This.saveToMemory(output, format)){
+        // Create new buffer then return address and size to user
+        *buffer = reinterpret_cast<unsigned char*>(std::malloc(output.size()));
+        *size = output.size();
+
+        // Copy vector contents into buffer
+        std::memcpy(*buffer, &output[0], output.size());
+        return sfTrue;
+    }
+
+    *buffer = NULL;
+    *size = 0;
+    return sfFalse;
 }
 
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -139,14 +139,10 @@ sfBool sfImage_saveToMemory(const sfImage* image, unsigned char** buffer, size_t
 {
     CSFML_CHECK_RETURN(image, sfFalse);
 
-    std::vector<sf::Uint8> output;
+    static std::vector<sf::Uint8> output;
     if (image->This.saveToMemory(output, format)){
-        // Create new buffer then return address and size to user
-        *buffer = reinterpret_cast<unsigned char*>(std::malloc(output.size()));
+        *buffer = &output[0];
         *size = output.size();
-
-        // Copy vector contents into buffer
-        std::memcpy(*buffer, &output[0], output.size());
         return sfTrue;
     }
 


### PR DESCRIPTION
Implements https://github.com/SFML/SFML/pull/1669

This one got complicated since we have to take a `std::vector` and convert it into something that can be returned from a C function. I hope I did it well. It does incur the cost of copying the entire buffer which is unfortunate but there is no way to tell a vector to relinquish control of its contents so copying the vector into a `malloc`'d buffer seems like my only option.