### PR TITLE
Expand CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Windows ClangCL, os: windows-2022, flags: -T ClangCL }
         - { name: Windows Clang,  os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
+        - { name: Windows MinGW,  os: windows-2022, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
         - { name: Linux GCC,      os: ubuntu-latest }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS,          os: macos-12,      flags: -DSFML_BUILD_FRAMEWORKS=FALSE }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Windows ClangCL, os: windows-2022, flags: -T ClangCL }
+        - { name: Windows Clang,  os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
         - { name: Linux GCC,      os: ubuntu-latest }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS,          os: macos-12,      flags: -DSFML_BUILD_FRAMEWORKS=FALSE }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         platform:
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
+        - { name: Windows ClangCL, os: windows-2022, flags: -T ClangCL }
         - { name: Linux GCC,      os: ubuntu-latest }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS,          os: macos-12,      flags: -DSFML_BUILD_FRAMEWORKS=FALSE }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Linux GCC,      os: ubuntu-latest }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: MacOS,          os: macos-12,      flags: -DSFML_BUILD_FRAMEWORKS=FALSE, prefix: sudo }
+        - { name: MacOS,          os: macos-12,      flags: -DSFML_BUILD_FRAMEWORKS=FALSE }
     steps:
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
@@ -34,7 +34,7 @@ jobs:
     
     - name: Build SFML
       shell: bash
-      run: ${{matrix.platform.prefix}} cmake --build $GITHUB_WORKSPACE/SFML/build --config Release --target install
+      run: cmake --build $GITHUB_WORKSPACE/SFML/build --config Release --target install
 
     - name: Checkout CSFML
       uses: actions/checkout@v3


### PR DESCRIPTION
This PR started off adding new compilers. Eventually I added static builds (instead of only shared builds) and quickly discovered there were some issues with incorrect `dllimport`/`dllexport` statements. I found out that CSFML lacked the same `CSFML_STATIC` definition that SFML has for supported static library builds so I ported that over from SFML in an identical fashion and now the new and improved CI pipeline is happy.

EDIT: I removed the static library bits so this PR is now only about adding CI jobs