### PR TITLE
Disable faulty Windows Clang job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Windows ClangCL, os: windows-2022, flags: -T ClangCL }
-        - { name: Windows Clang,  os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
+        # - { name: Windows Clang,  os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
         - { name: Windows MinGW,  os: windows-2022, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
         - { name: Linux GCC,      os: ubuntu-latest }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }


### PR DESCRIPTION
The problem is that the Windows CI image hasn't yet be updated to Clang 16. See this PR for progress on fixing it

https://github.com/actions/runner-images/pull/8134

This has been merged but we still have to wait for the changes to propogate to all runners.