### PR TITLE
Do not pass C++ warning options to C compiler

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -39,17 +39,17 @@ function(set_file_warnings)
     set(CLANG_AND_GCC_WARNINGS
         -Wall
         -Wextra # reasonable and standard
-        -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
+        $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor> # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
         -Wcast-align # warn for potential performance problem casts
         -Wunused # warn on anything being unused
-        -Woverloaded-virtual # warn if you overload (not override) a virtual function
+        $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual> # warn if you overload (not override) a virtual function
         -Wconversion # warn on type conversions that may lose data
         -Wsign-conversion # warn on sign conversions
         -Wdouble-promotion # warn if float is implicit promoted to double
         -Wformat=2 # warn on security issues around functions that format output (ie printf)
         # -Wimplicit-fallthrough # warn when a missing break causes control flow to continue at the next case in a switch statement (disabled until better compiler support for explicit fallthrough is available)
         -Wnull-dereference # warn if a null dereference is detected
-        -Wold-style-cast # warn for c-style casts
+        $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast> # warn for c-style casts
         -Wpedantic # warn if non-standard C++ is used
         -Wno-deprecated-declarations # do not warning about deprecated declarations
         -Wno-language-extension-token # ignore use of __int64 compiler extension


### PR DESCRIPTION
GCC outputs warnings about C++ flags when compiling the C example.

> cc1: warning: command-line option ‘-Wnon-virtual-dtor’ is valid for C++/ObjC++ but not for C
> cc1: warning: command-line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C
> cc1: warning: command-line option ‘-Wold-style-cast’ is valid for C++/ObjC++ but not for C

Using CMake generator expression [COMPILE_LANGUAGE](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#boolean-compile-language-generator-expression) to make some flags active only when compiling C++ solves it.