### PR TITLE
Minor fixes of the documentation

### DIFF
--- a/include/SFML/Audio/SoundRecorder.h
+++ b/include/SFML/Audio/SoundRecorder.h
@@ -135,11 +135,11 @@ CSFML_AUDIO_API sfBool sfSoundRecorder_isAvailable(void);
 CSFML_AUDIO_API void sfSoundRecorder_setProcessingInterval(sfSoundRecorder* soundRecorder, sfTime interval);
 
 ////////////////////////////////////////////////////////////
-/// \brief Get a list of the names of all availabe audio capture devices
+/// \brief Get a list of the names of all available audio capture devices
 ///
 /// This function returns an array of strings (null terminated),
-/// containing the names of all availabe audio capture devices.
-/// If no devices are available then NULL is returned.
+/// containing the names of all available audio capture devices.
+/// If no devices are available, then NULL is returned.
 ///
 /// \param count Pointer to a variable that will be filled with the number of modes in the array
 ///

--- a/include/SFML/Graphics/RenderTexture.h
+++ b/include/SFML/Graphics/RenderTexture.h
@@ -237,7 +237,7 @@ CSFML_GRAPHICS_API void sfRenderTexture_drawVertexBuffer(sfRenderTexture* render
 /// \brief Draw primitives defined by a vertex buffer.
 ///
 /// \param renderTexture render texture object
-/// \param vertexBuffer  Vertex buffer object to draw
+/// \param object        Vertex buffer object to draw
 /// \param firstVertex   Index of the first vertex to render
 /// \param vertexCount   Number of vertices to render
 /// \param states        Render states to use for drawing

--- a/include/SFML/Graphics/RenderWindow.h
+++ b/include/SFML/Graphics/RenderWindow.h
@@ -479,8 +479,8 @@ CSFML_GRAPHICS_API void sfRenderWindow_drawVertexBuffer(sfRenderWindow* renderWi
 ////////////////////////////////////////////////////////////
 /// \brief Draw primitives defined by a vertex buffer.
 ///
-/// \param renderWindow render window object
-/// \param vertexBuffer Vertex buffer object to draw
+/// \param renderWindow Render window object
+/// \param object       Vertex buffer object to draw
 /// \param firstVertex  Index of the first vertex to render
 /// \param vertexCount  Number of vertices to render
 /// \param states       Render states to use for drawing

--- a/include/SFML/Window/Context.h
+++ b/include/SFML/Window/Context.h
@@ -55,7 +55,7 @@ CSFML_WINDOW_API void sfContext_destroy(sfContext* context);
 ////////////////////////////////////////////////////////////
 /// \brief Check whether a given OpenGL extension is available.
 ///
-/// \param Name of the extension to check for
+/// \param name Name of the extension to check for
 ///
 /// \return True if available, false if unavailable
 ///
@@ -85,6 +85,8 @@ CSFML_WINDOW_API GlFunctionPointer sfContext_getFunction(const char* name);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the settings of the context.
+///
+/// \param context Context object
 ///
 /// Note that these settings may be different than the ones passed to the
 /// constructor; they are indeed adjusted if the original settings are not


### PR DESCRIPTION
- Parameter names not matching the actual code identifier
- Typo in SoundRecorder.h
- Missing param in Context.h