### PR TITLE
[FIX] just a spelling mistake in the TcpSocket.h

### DIFF
--- a/include/SFML/Network/TcpSocket.h
+++ b/include/SFML/Network/TcpSocket.h
@@ -95,7 +95,7 @@ CSFML_NETWORK_API unsigned short sfTcpSocket_getLocalPort(const sfTcpSocket* soc
 ////////////////////////////////////////////////////////////
 /// \brief Get the address of the connected peer of a TCP socket
 ///
-/// It the socket is not connected, this function returns
+/// If the socket is not connected, this function returns
 /// sfIpAddress_None.
 ///
 /// \param socket TCP socket object


### PR DESCRIPTION
I'm a first-year student and i was browsing the network part of csfml and I notice there is just an "It" instead of an "If" in the description of sfTcpSocket_getRemotePort