### PR TITLE
Use bash by default in all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ concurrency:
   group: environment-${{github.ref}}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: ${{ matrix.platform.name }} ${{ matrix.type.name }}
@@ -46,11 +50,9 @@ jobs:
         path: SFML
 
     - name: Configure SFML CMake
-      shell: bash
       run: cmake -S SFML -B SFML/build -DCMAKE_INSTALL_PREFIX=SFML/install -DBUILD_SHARED_LIBS=TRUE -DSFML_BUILD_EXAMPLES=FALSE -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build SFML
-      shell: bash
       run: cmake --build SFML/build --config ${{matrix.type.name}} --target install
 
     - name: Checkout CSFML
@@ -59,9 +61,7 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      shell: bash
       run: cmake -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DBUILD_SHARED_LIBS=TRUE -DCSFML_BUILD_EXAMPLES=TRUE -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON -DWARNINGS_AS_ERRORS=TRUE ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build CSFML
-      shell: bash
       run: cmake --build CSFML/build --config ${{matrix.type.name}} --target install


### PR DESCRIPTION
In the past we've dealt with some obscure errors due to certain jobs accidentally using a shell other than Bash. Specifying this on a global basis makes those errors not possible.