### PR TITLE
Add unit testing infrastructure and initial unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      run: cmake -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DBUILD_SHARED_LIBS=TRUE -DCSFML_BUILD_EXAMPLES=TRUE -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON -DWARNINGS_AS_ERRORS=TRUE ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
+      run: cmake -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DBUILD_SHARED_LIBS=TRUE -DCSFML_BUILD_EXAMPLES=TRUE -DCSFML_BUILD_TEST_SUITE=TRUE -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON -DWARNINGS_AS_ERRORS=TRUE ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build CSFML
       run: cmake --build CSFML/build --config ${{matrix.type.name}} --target install
+
+    - name: Test
+      run: ctest --test-dir CSFML/build -C ${{matrix.type.name}} --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,6 @@ else()
 endif()
 csfml_set_option(CSFML_LINK_SFML_STATICALLY ${LINK_STATICALLY_DEFAULT} BOOL "TRUE to link to a static version of SFML, FALSE to link dynamically")
 
-# disable the rpath stuff
-set(CMAKE_SKIP_BUILD_RPATH TRUE)
-
 # define an option for choosing between static and dynamic C runtime (Windows only)
 if(SFML_OS_WINDOWS)
     set(STATIC_STD_LIBS FALSE CACHE BOOL "TRUE to statically link to the standard libraries, FALSE to use them as DLLs")
@@ -96,4 +93,11 @@ install(FILES readme.md DESTINATION ${INSTALL_MISC_DIR})
 csfml_set_option(CSFML_BUILD_EXAMPLES FALSE BOOL "TRUE to build the CSFML examples, FALSE to ignore them")
 if(CSFML_BUILD_EXAMPLES)
     add_subdirectory(examples)
+endif()
+
+# add an option for building the tests
+csfml_set_option(CSFML_BUILD_TEST_SUITE FALSE BOOL "TRUE to build the CSFML test suite, FALSE to ignore it")
+if(CSFML_BUILD_TEST_SUITE)
+    enable_testing()
+    add_subdirectory(test)
 endif()

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -66,9 +66,7 @@ macro(csfml_add_library target)
     # build dylibs
     if(SFML_OS_MACOSX AND BUILD_SHARED_LIBS)
         # adapt install directory to allow distributing dylibs in user’s application bundle
-        set_target_properties(${target} PROPERTIES
-                              BUILD_WITH_INSTALL_RPATH 1
-                              INSTALL_NAME_DIR "@rpath")
+        set_target_properties(${target} PROPERTIES INSTALL_NAME_DIR "@rpath")
     endif()
 
     # add the install rule

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,36 @@
+include(FetchContent)
+
+set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
+set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
+FetchContent_Declare(Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.5.3
+    GIT_SHALLOW ON)
+FetchContent_MakeAvailable(Catch2)
+include(Catch)
+
+# Build Catch2 in C++17 mode to enable C++17 features
+target_compile_features(Catch2 PRIVATE cxx_std_17)
+
+# Ensure that Catch2 sources and headers are not analyzed by any tools
+set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
+set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
+
+add_executable(test-csfml-system
+    System/Buffer.test.cpp
+    System/Clock.test.cpp
+    System/Sleep.test.cpp
+    System/Time.test.cpp
+    System/Vector2.test.cpp
+    System/Vector3.test.cpp
+)
+target_link_libraries(test-csfml-system PRIVATE csfml-system Catch2::Catch2WithMain)
+set_target_warnings(test-csfml-system)
+catch_discover_tests(test-csfml-system)
+
+# Copy DLLs into the same directory
+if(SFML_OS_WINDOWS AND NOT CSFML_LINK_SFML_STATICALLY)
+    add_custom_command(TARGET test-csfml-system PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-system> $<TARGET_FILE_DIR:test-csfml-system> COMMAND_EXPAND_LISTS)
+endif()

--- a/test/System/Buffer.test.cpp
+++ b/test/System/Buffer.test.cpp
@@ -1,0 +1,11 @@
+#include <SFML/System/Buffer.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[System] sfBuffer")
+{
+    sfBuffer* buffer = sfBuffer_create();
+    CHECK(sfBuffer_getSize(buffer) == 0);
+    CHECK(sfBuffer_getData(buffer) == 0);
+    sfBuffer_destroy(buffer);
+}

--- a/test/System/Clock.test.cpp
+++ b/test/System/Clock.test.cpp
@@ -1,0 +1,25 @@
+#include <SFML/System/Clock.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+
+TEST_CASE("[System] sfClock")
+{
+    sfClock* clock = sfClock_create();
+    
+    CHECK(sfTime_asMicroseconds(sfClock_getElapsedTime(clock)) >= 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    CHECK(sfTime_asMicroseconds(sfClock_getElapsedTime(clock)) >= 1'000);
+
+    sfClock_restart(clock);
+    CHECK(sfTime_asMicroseconds(sfClock_getElapsedTime(clock)) >= 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    CHECK(sfTime_asMicroseconds(sfClock_getElapsedTime(clock)) >= 1'000);
+
+    sfClock* anotherClock = sfClock_copy(clock);
+    CHECK(sfTime_asMicroseconds(sfClock_getElapsedTime(anotherClock)) >= 1'000);
+
+    sfClock_destroy(anotherClock);
+    sfClock_destroy(clock);
+}

--- a/test/System/Sleep.test.cpp
+++ b/test/System/Sleep.test.cpp
@@ -1,0 +1,11 @@
+#include <SFML/System/Sleep.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[System] sfSleep")
+{       
+    const auto startTime = std::chrono::steady_clock::now();
+    sfSleep(sfMilliseconds(10));
+    const auto elapsed = std::chrono::steady_clock::now() - startTime;
+    CHECK(elapsed >= std::chrono::milliseconds(10));
+}

--- a/test/System/Time.test.cpp
+++ b/test/System/Time.test.cpp
@@ -1,0 +1,31 @@
+#include <SFML/System/Time.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[System] sfTime")
+{
+    CHECK(sfTime_Zero.microseconds == 0);
+
+    sfTime time{};
+    CHECK(time.microseconds == 0);
+    CHECK(sfTime_asSeconds(time) == 0);
+    CHECK(sfTime_asMilliseconds(time) == 0);
+    CHECK(sfTime_asMicroseconds(time) == 0);
+
+    time.microseconds = 1'234'567;
+    CHECK(sfTime_asSeconds(time) == 1.234567f);
+    CHECK(sfTime_asMilliseconds(time) == 1234);
+    CHECK(sfTime_asMicroseconds(time) == 1'234'567);
+
+    CHECK(sfSeconds(0).microseconds == 0);
+    CHECK(sfMilliseconds(0).microseconds == 0);
+    CHECK(sfMicroseconds(0).microseconds == 0);
+
+    CHECK(sfSeconds(1).microseconds == 1'000'000);
+    CHECK(sfMilliseconds(1).microseconds == 1'000);
+    CHECK(sfMicroseconds(1).microseconds == 1);
+
+    CHECK(sfSeconds(10).microseconds == 10'000'000);
+    CHECK(sfMilliseconds(10).microseconds == 10'000);
+    CHECK(sfMicroseconds(10).microseconds == 10);
+}

--- a/test/System/Vector2.test.cpp
+++ b/test/System/Vector2.test.cpp
@@ -1,0 +1,27 @@
+#include <SFML/System/Vector2.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[System] sfVector2")
+{
+    SECTION("sfVector2i")
+    {
+        const sfVector2i vector{};
+        CHECK(vector.x == 0);
+        CHECK(vector.y == 0);
+    }
+
+    SECTION("sfVector2u")
+    {
+        const sfVector2u vector{};
+        CHECK(vector.x == 0);
+        CHECK(vector.y == 0);
+    }
+
+    SECTION("sfVector2f")
+    {
+        const sfVector2f vector{};
+        CHECK(vector.x == 0);
+        CHECK(vector.y == 0);
+    }
+}

--- a/test/System/Vector3.test.cpp
+++ b/test/System/Vector3.test.cpp
@@ -1,0 +1,13 @@
+#include <SFML/System/Vector3.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[System] sfVector3")
+{
+    SECTION("sfVector3f")
+    {
+        const sfVector3f vector{};
+        CHECK(vector.x == 0);
+        CHECK(vector.y == 0);
+    }
+}


### PR DESCRIPTION
Waiting on #242 

For the most part this PR copies over the same testing infrastructure that SFML already uses. The unit tests themselves are written in C++ because C++ provides more options for writing expressive tests plus it means more in similar with SFML's tests which makes for easier maintenance. Writing our tests in pure C would not be particularly useful.

I had to make a few changes to how rpaths are treated to get the tests to work. CMake's default handling of rpaths seems to work just fine but the custom settings we were using were breaking things. I'm not sure why `CMAKE_SKIP_BUILD_RPATH` was enabled but I feel comfortable removing that. Build-time rpaths are useful. I'm also not sure why `BUILD_WITH_INSTALL_RPATH` was enabled for macOS dylibs but I also had to remove that to get the tests to work on macOS.