### PR TITLE
Add `sfJoystick` tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.5.3
+    GIT_TAG v3.6.0
     GIT_SHALLOW ON)
 FetchContent_MakeAvailable(Catch2)
 include(Catch)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,15 @@ target_link_libraries(test-csfml-system PRIVATE csfml-system Catch2::Catch2WithM
 set_target_warnings(test-csfml-system)
 catch_discover_tests(test-csfml-system)
 
+add_executable(test-csfml-window
+    Window/Joystick.test.cpp
+)
+target_link_libraries(test-csfml-window PRIVATE csfml-window Catch2::Catch2WithMain)
+set_target_warnings(test-csfml-window)
+catch_discover_tests(test-csfml-window)
+
 # Copy DLLs into the same directory
 if(SFML_OS_WINDOWS AND NOT CSFML_LINK_SFML_STATICALLY)
     add_custom_command(TARGET test-csfml-system PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-system> $<TARGET_FILE_DIR:test-csfml-system> COMMAND_EXPAND_LISTS)
+    add_custom_command(TARGET test-csfml-window PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-window> $<TARGET_FILE_DIR:test-csfml-window> COMMAND_EXPAND_LISTS)
 endif()

--- a/test/Window/Joystick.test.cpp
+++ b/test/Window/Joystick.test.cpp
@@ -1,0 +1,68 @@
+#include <SFML/Window/Joystick.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+TEST_CASE("[Window] sfJoystick")
+{
+    SECTION("Constants")
+    {
+        STATIC_CHECK(sfJoystickCount == 8);
+        STATIC_CHECK(sfJoystickButtonCount == 32);
+        STATIC_CHECK(sfJoystickAxisCount == 8);
+    }
+
+    // By avoiding calling sfJoystick_update() we can guarantee that
+    // no joysticks will be detected. This is how we can ensure these
+    // tests are portable and reliable.
+
+    const auto joystick = GENERATE(range(0u, static_cast<unsigned int>(sfJoystickCount - 1)));
+
+    SECTION("sfJoystick_isConnected()")
+    {
+        CHECK(!sfJoystick_isConnected(joystick));
+    }
+
+    SECTION("sfJoystick_getButtonCount()")
+    {
+        CHECK(sfJoystick_getButtonCount(joystick) == 0);
+    }
+
+    SECTION("sfJoystick_hasAxis()")
+    {
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickX));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickY));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickZ));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickR));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickU));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickV));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickPovX));
+        CHECK(!sfJoystick_hasAxis(joystick, sfJoystickPovY));
+    }
+
+    SECTION("sfJoystick_isButtonPressed()")
+    {
+        const auto button = GENERATE(range(0u, static_cast<unsigned int>(sfJoystickButtonCount - 1)));
+        CHECK(!sfJoystick_isButtonPressed(joystick, button));
+    }
+
+    SECTION("sfJoystick_getAxisPosition")
+    {
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickX) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickY) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickZ) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickR) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickU) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickV) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickPovX) == 0);
+        CHECK(sfJoystick_getAxisPosition(joystick, sfJoystickPovY) == 0);
+    }
+
+    SECTION("getIdentification()")
+    {
+        const auto identification = sfJoystick_getIdentification(joystick);
+        CHECK(identification.name == std::string("No Joystick"));
+        CHECK(identification.vendorId == 0);
+        CHECK(identification.productId == 0);
+    }
+}


### PR DESCRIPTION
Most Window module APIs require a display which means pulling in the same `xvfb` infrastructure SFML uses. We can do that eventually, but for now I wrote some quick `sfJoystick` tests since these don't require a display to be ran in CI.

This is yet another instance where having CSFML live inside SFML/SFML would be useful since it could easily pick up the existing infrastructure SFML has like this `xvfb` stuff or our clang-format and clang-tidy infrastructure. This is certainly out of scope for SFML 3 but it's still something I'm considering for the future since I think it's both feasible and beneficial.