### PR TITLE
Reduce duplicated Linux and macOS libraries in NuGet Package

### DIFF
--- a/src/SFML/CMakeLists.txt
+++ b/src/SFML/CMakeLists.txt
@@ -28,6 +28,9 @@ endif()
 if(CSFML_BUILD_GRAPHICS)
     list(PREPEND SFML_MODULES "graphics")
 endif()
+if(CSFML_BUILD_WINDOW)
+    list(PREPEND SFML_MODULES "window")
+endif()
 if(CSFML_BUILD_NETWORK)
     list(PREPEND SFML_MODULES "network")
 endif()
@@ -36,7 +39,7 @@ find_package(SFML 2.6 COMPONENTS ${SFML_MODULES} REQUIRED)
 # add the modules subdirectories
 add_subdirectory(System)
 
-if(CSFML_BUILD_WINDOW OR SFML_BUILD_GRAPHICS)
+if(CSFML_BUILD_WINDOW OR CSFML_BUILD_GRAPHICS)
     add_subdirectory(Window)
 endif()
 

--- a/tools/nuget/CSFML/build/netstandard2.0/CSFML.props
+++ b/tools/nuget/CSFML/build/netstandard2.0/CSFML.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <CSFMLIgnoreAnyCPU>true</CSFMLIgnoreAnyCPU>
+    </PropertyGroup>
+</Project>

--- a/tools/nuget/CSFML/build/netstandard2.0/CSFML.props
+++ b/tools/nuget/CSFML/build/netstandard2.0/CSFML.props
@@ -2,5 +2,7 @@
 <Project ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <CSFMLIgnoreAnyCPU>true</CSFMLIgnoreAnyCPU>
+        <!-- Silence warning about the fedora-x64 libraries -->
+        <NoWarn>NETSDK1206</NoWarn>
     </PropertyGroup>
 </Project>

--- a/tools/nuget/build.linux.sh
+++ b/tools/nuget/build.linux.sh
@@ -127,6 +127,9 @@ cmake --build . --config Release
 # STEP 5: Copy result to the NuGet folders #
 # ======================================== #
 
+SFMLMajorMinor="2.6"
+CSFMLMajorMinor="2.6"
+
 # Copies one SFML and CSFML module into the NuGet package
 # The module name must be passed to this function as an argument, in lowercase
 # This function then copies $SFMLLibDir/libsfml-(module).so and
@@ -137,14 +140,15 @@ copymodule()
 
     mkdir -p "$OutDir"
 
-    # Note the wildcard at the end of the first argument
-    # We are copying every versioned file here, not just the .so
-    # (libsfml-audio.so, libsfml-audio.so.2, libsfml-audio.so.2.6, etc)
-    # This is needed because of the way linux searches for libraries based
-    # one their SONAME
-    cp "$SFMLLibDir/libsfml-$MODULE.so"* "$OutDir"
-
+    # SFML.Net only searches for the name with common pre- and suffixes
+    # As such we need to ship e.g. libcsfml-graphics.so
+    # But the CSFML libs will look for the major.minor version
+    # As such we also need to ship e.g. libcsfml-graphics.so.2.6
+    # Unfortunately NuGet package don't support symlinks: https://github.com/NuGet/Home/issues/10734
+    # For SFML, we can just ship one version that CSFML will be looking for
+    cp "$SFMLLibDir/libsfml-$MODULE.so.$SFMLMajorMinor" "$OutDir"
     cp "$CSFMLLibDir/libcsfml-$MODULE.so" "$OutDir"
+    cp "$CSFMLLibDir/libcsfml-$MODULE.so.$CSFMLMajorMinor" "$OutDir"
 }
 
 copymodule audio

--- a/tools/nuget/build.macos.sh
+++ b/tools/nuget/build.macos.sh
@@ -193,19 +193,15 @@ copymodule()
 
     mkdir -p "$OutDir"
 
-    # Note the wildcard at the end of the first argument
-    # We are copying every versioned file here, not just the .dylib
-    # (libsfml-audio.dylib, libsfml-audio.2.dylib, libsfml-audio.2.6.dylib, etc)
-    # This is needed because of the way macOS searches for libraries based
-    # one their SONAME
-    cp "$SFMLLibDir/libsfml-$MODULE."* "$OutDir"
-
-    cp "$CSFMLLibDir/libcsfml-$MODULE."* "$OutDir"
-
-    # Fix naming for expected filename
-    mv "$OutDir/libcsfml-$MODULE.dylib" "$OutDir/libcsfml-$MODULE"
-    mv "$OutDir/libcsfml-$MODULE.$CSFMLMajorMinor.dylib" "$OutDir/libcsfml-$MODULE.$CSFMLMajorMinor"
-    mv "$OutDir/libcsfml-$MODULE.$CSFMLMajorMinorPatch.dylib" "$OutDir/libcsfml-$MODULE.$CSFMLMajorMinorPatch"
+    # SFML.Net only searches for the name with common pre- and suffixes
+    # As such we need to ship e.g. libcsfml-graphics.dylib
+    # But the CSFML libs will look for the major.minor version
+    # As such we also need to ship e.g. libcsfml-graphics.2.6.dylib
+    # Unfortunately NuGet package don't support symlinks: https://github.com/NuGet/Home/issues/10734
+    # For SFML, we can just ship one version that CSFML will be looking for
+    cp "$SFMLLibDir/libsfml-$MODULE.$SFMLMajorMinor.dylib" "$OutDir"
+    cp "$CSFMLLibDir/libcsfml-$MODULE.dylib" "$OutDir"
+    cp "$CSFMLLibDir/libcsfml-$MODULE.$CSFMLMajorMinor.dylib" "$OutDir"
 }
 
 copymodule audio


### PR DESCRIPTION
As NuGet doesn't support symlinks (https://github.com/NuGet/Home/issues/10734), we either have to ship all the libraries in three different versions, or ensure that we're only ever using the one version everywhere.

To reduce duplication and unnecessary size, we'll only use the `(c)sfml-*.so.2.6` or `(c)sfml-*.2.6.dylib` respectively. See also https://github.com/SFML/SFML.Net/pull/247

Also fixes the issues reported by @kimci86 in #249 