### PR TITLE
Temporarily lock SFML revision used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: SFML/SFML
-        ref: master
+        ref: c89c32d7baa15927a39a161a4ead867c11d5ea21
         path: SFML
 
     - name: Configure SFML CMake

--- a/tools/nuget/build.linux.sh
+++ b/tools/nuget/build.linux.sh
@@ -43,6 +43,7 @@ echo "Please note that all SFML dependencies must be installed and available to 
 RID="$1"
 
 SFMLBranch="master" # The branch or tag of the SFML repository to be cloned
+SFMLCommit="c89c32d7baa15927a39a161a4ead867c11d5ea21" # Specific locked commit
 CSFMLDir="$(realpath ../../)"  # The directory of the source code of CSFML
 
 OutDir="./CSFML/runtimes/$RID/native" # The base directory of all CSFML modules, used to copy the final libraries
@@ -62,6 +63,12 @@ if [[ ! -d "SFML/.git" ]]; then
     echo "Cloning SFML"
     rm -rf "SFML"
     git clone --branch "$SFMLBranch" --depth 1 "https://github.com/SFML/SFML.git" "SFML"
+fi
+
+if [ "$SFMLCommit" != "" ]; then
+    cd SFML
+    git checkout c89c32d7baa15927a39a161a4ead867c11d5ea21
+    cd ..
 fi
 
 SFMLDir="$(realpath SFML)"

--- a/tools/nuget/build.macos.sh
+++ b/tools/nuget/build.macos.sh
@@ -47,6 +47,7 @@ echo "Please note that all SFML dependencies must be installed and available to 
 RID="$1"
 
 SFMLBranch="master" # The branch or tag of the SFML repository to be cloned
+SFMLCommit="c89c32d7baa15927a39a161a4ead867c11d5ea21" # Specific locked commit
 CSFMLDir="$(grealpath "$(git rev-parse --show-toplevel)")" # The directory of the source code of CSFML
 
 OutDir="./CSFML/runtimes/$RID/native" # The base directory of all CSFML modules, used to copy the final libraries
@@ -66,6 +67,12 @@ if [[ ! -d "SFML/.git" ]]; then
     echo "Cloning SFML"
     rm -rf "SFML"
     git clone --branch "$SFMLBranch" --depth 1 "https://github.com/SFML/SFML.git" "SFML"
+fi
+
+if [ "$SFMLCommit" != "" ]; then
+    cd SFML
+    git checkout c89c32d7baa15927a39a161a4ead867c11d5ea21
+    cd ..
 fi
 
 SFMLDir="$(grealpath SFML)"

--- a/tools/nuget/build.win.ps1
+++ b/tools/nuget/build.win.ps1
@@ -36,6 +36,7 @@ Write-Output "Using $Generator as the cmake generator"
 Write-Output "Using architecture $Architecture"
 
 $SFMLBranch = "master" # The branch or tag of the SFML repository to be cloned
+$SFMLCommit = "c89c32d7baa15927a39a161a4ead867c11d5ea21" # Specific locked commit
 $CSFMLDir = (Get-Item (git rev-parse --show-toplevel)).FullName # The directory of the source code of CSFML
 
 $OutDir = "./CSFML/runtimes/$RID/native" # The directory of all CSFML modules, used to copy the final dlls
@@ -80,6 +81,10 @@ If (-not (Test-Path "SFML/.git")) {
 }
 
 Push-Location "SFML"
+
+If ($SFMLCommit) {
+    git checkout $SFMLCommit
+}
 
 $SFMLDir = (Get-Item .).FullName
 


### PR DESCRIPTION
The SFML 3 API is changing faster than I care to update in CSFML. *I can't stand whatever guy keeps breaking the SFML API*. Anyways, for now let's lock CSFML to a particular revision of SFML until the SFML 3 API changes slow down and we can go back to tracking the master branch.