### PR TITLE
Documentation: Fix last value of index range in FTP listing response

### DIFF
--- a/include/CSFML/Graphics/ConvexShape.h
+++ b/include/CSFML/Graphics/ConvexShape.h
@@ -390,7 +390,7 @@ CSFML_GRAPHICS_API void sfConvexShape_setPointCount(sfConvexShape* shape, size_t
 /// of the valid range.
 ///
 /// \param shape Shape object
-/// \param index Index of the point to change, in range [0 .. GetPointCount() - 1]
+/// \param index Index of the point to change, in range [0 .. getPointCount() - 1]
 /// \param point New point
 ///
 ////////////////////////////////////////////////////////////

--- a/include/CSFML/Network/Ftp.h
+++ b/include/CSFML/Network/Ftp.h
@@ -169,7 +169,7 @@ CSFML_NETWORK_API size_t sfFtpListingResponse_getCount(const sfFtpListingRespons
 /// \brief Return a directory/file name contained in a FTP listing response
 ///
 /// \param ftpListingResponse Ftp listing response
-/// \param index              Index of the name to get (in range [0 .. getCount])
+/// \param index              Index of the name to get, in range [0 .. getCount() - 1]
 ///
 /// \return The requested name
 ///


### PR DESCRIPTION
- Wording and notation consistent with `sf*Shape_{g,s}etPoint()`
- Related case fix in `sfConvexShape_setPoint`