### PR TITLE
Revert "Temporarily lock SFML revision used in CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: SFML/SFML
-        ref: 8096ba24fccb6b76a7d9e8cc71a3afb7b02e517c
+        ref: master
         path: SFML
 
     - name: Configure SFML CMake

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,8 @@ set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
 
+set(CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
+
 add_executable(test-csfml-system
     System/Buffer.test.cpp
     System/Clock.test.cpp
@@ -39,6 +41,6 @@ catch_discover_tests(test-csfml-window)
 
 # Copy DLLs into the same directory
 if(SFML_OS_WINDOWS AND NOT CSFML_LINK_SFML_STATICALLY)
-    add_custom_command(TARGET test-csfml-system PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-system> $<TARGET_FILE_DIR:test-csfml-system> COMMAND_EXPAND_LISTS)
-    add_custom_command(TARGET test-csfml-window PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-window> $<TARGET_FILE_DIR:test-csfml-window> COMMAND_EXPAND_LISTS)
+    add_custom_command(TARGET test-csfml-system POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-system> $<TARGET_FILE_DIR:test-csfml-system> COMMAND_EXPAND_LISTS)
+    add_custom_command(TARGET test-csfml-window POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-window> $<TARGET_FILE_DIR:test-csfml-window> COMMAND_EXPAND_LISTS)
 endif()


### PR DESCRIPTION
This reverts commit 36a6e7c5a617b3f6cdb6bac9a9613e516ea6ba6e.

Now that SFML 3's API is mostly stable we no longer need to lock down the specific commit hash. 