### PR TITLE
CMake: Fix installing HTML Help with newer Doxygen version

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(doc ALL
 install(DIRECTORY ${DOXYGEN_OUTPUT_DIR}/html
         DESTINATION ${INSTALL_MISC_DIR}/doc
         COMPONENT doc)
-if(DOXYGEN_HHC_PROGRAM)
+if(DOXYGEN_GENERATE_HTMLHELP)
     install(FILES ${DOXYGEN_OUTPUT_DIR}/CSFML.chm
             DESTINATION ${INSTALL_MISC_DIR}/doc
             COMPONENT doc)


### PR DESCRIPTION
HTML Help generation was disabled for doxygen version greater than 1.10.0 in df75efa78d41e39427168355659e48f8d2e6e7d8 commit.