### PR TITLE
Remove unnecessary `(void)` parameters from C++ implementations

### DIFF
--- a/src/CSFML/Audio/Listener.cpp
+++ b/src/CSFML/Audio/Listener.cpp
@@ -38,7 +38,7 @@ void sfListener_setGlobalVolume(float volume)
 
 
 ////////////////////////////////////////////////////////////
-float sfListener_getGlobalVolume(void)
+float sfListener_getGlobalVolume()
 {
     return sf::Listener::getGlobalVolume();
 }

--- a/src/CSFML/Audio/SoundBufferRecorder.cpp
+++ b/src/CSFML/Audio/SoundBufferRecorder.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfSoundBufferRecorder* sfSoundBufferRecorder_create(void)
+sfSoundBufferRecorder* sfSoundBufferRecorder_create()
 {
     return new sfSoundBufferRecorder;
 }

--- a/src/CSFML/Audio/SoundRecorder.cpp
+++ b/src/CSFML/Audio/SoundRecorder.cpp
@@ -69,7 +69,7 @@ unsigned int sfSoundRecorder_getSampleRate(const sfSoundRecorder* soundRecorder)
 
 
 ////////////////////////////////////////////////////////////
-bool sfSoundRecorder_isAvailable(void)
+bool sfSoundRecorder_isAvailable()
 {
     return sf::SoundRecorder::isAvailable();
 }

--- a/src/CSFML/Graphics/CircleShape.cpp
+++ b/src/CSFML/Graphics/CircleShape.cpp
@@ -33,7 +33,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfCircleShape* sfCircleShape_create(void)
+sfCircleShape* sfCircleShape_create()
 {
     sfCircleShape* shape = new sfCircleShape;
     shape->Texture = nullptr;

--- a/src/CSFML/Graphics/ConvexShape.cpp
+++ b/src/CSFML/Graphics/ConvexShape.cpp
@@ -33,7 +33,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfConvexShape* sfConvexShape_create(void)
+sfConvexShape* sfConvexShape_create()
 {
     return new sfConvexShape;
 }

--- a/src/CSFML/Graphics/RectangleShape.cpp
+++ b/src/CSFML/Graphics/RectangleShape.cpp
@@ -33,7 +33,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfRectangleShape* sfRectangleShape_create(void)
+sfRectangleShape* sfRectangleShape_create()
 {
     return new sfRectangleShape;
 }

--- a/src/CSFML/Graphics/Shader.cpp
+++ b/src/CSFML/Graphics/Shader.cpp
@@ -389,14 +389,14 @@ void sfShader_bind(const sfShader* shader)
 
 
 ////////////////////////////////////////////////////////////
-bool sfShader_isAvailable(void)
+bool sfShader_isAvailable()
 {
     return sf::Shader::isAvailable();
 }
 
 
 ////////////////////////////////////////////////////////////
-bool sfShader_isGeometryAvailable(void)
+bool sfShader_isGeometryAvailable()
 {
     return sf::Shader::isGeometryAvailable();
 }

--- a/src/CSFML/Graphics/Transformable.cpp
+++ b/src/CSFML/Graphics/Transformable.cpp
@@ -32,7 +32,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfTransformable* sfTransformable_create(void)
+sfTransformable* sfTransformable_create()
 {
     sfTransformable* transformable = new sfTransformable;
 

--- a/src/CSFML/Graphics/VertexArray.cpp
+++ b/src/CSFML/Graphics/VertexArray.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfVertexArray* sfVertexArray_create(void)
+sfVertexArray* sfVertexArray_create()
 {
     return new sfVertexArray;
 }

--- a/src/CSFML/Graphics/View.cpp
+++ b/src/CSFML/Graphics/View.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfView* sfView_create(void)
+sfView* sfView_create()
 {
     return new sfView;
 }

--- a/src/CSFML/Network/Ftp.cpp
+++ b/src/CSFML/Network/Ftp.cpp
@@ -167,7 +167,7 @@ const char* sfFtpResponse_getMessage(const sfFtpResponse* ftpResponse)
 
 
 ////////////////////////////////////////////////////////////
-sfFtp* sfFtp_create(void)
+sfFtp* sfFtp_create()
 {
     return new sfFtp;
 }

--- a/src/CSFML/Network/Http.cpp
+++ b/src/CSFML/Network/Http.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfHttpRequest* sfHttpRequest_create(void)
+sfHttpRequest* sfHttpRequest_create()
 {
     return new sfHttpRequest;
 }
@@ -132,7 +132,7 @@ const char* sfHttpResponse_getBody(const sfHttpResponse* httpResponse)
 
 
 ////////////////////////////////////////////////////////////
-sfHttp* sfHttp_create(void)
+sfHttp* sfHttp_create()
 {
     return new sfHttp;
 }

--- a/src/CSFML/Network/IpAddress.cpp
+++ b/src/CSFML/Network/IpAddress.cpp
@@ -107,7 +107,7 @@ uint32_t sfIpAddress_toInteger(sfIpAddress address)
 
 
 ////////////////////////////////////////////////////////////
-sfIpAddress sfIpAddress_getLocalAddress(void)
+sfIpAddress sfIpAddress_getLocalAddress()
 {
     return fromSFMLAddress(sf::IpAddress::getLocalAddress());
 }

--- a/src/CSFML/Network/Packet.cpp
+++ b/src/CSFML/Network/Packet.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfPacket* sfPacket_create(void)
+sfPacket* sfPacket_create()
 {
     return new sfPacket;
 }

--- a/src/CSFML/Network/SocketSelector.cpp
+++ b/src/CSFML/Network/SocketSelector.cpp
@@ -34,7 +34,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfSocketSelector* sfSocketSelector_create(void)
+sfSocketSelector* sfSocketSelector_create()
 {
     return new sfSocketSelector;
 }

--- a/src/CSFML/Network/TcpListener.cpp
+++ b/src/CSFML/Network/TcpListener.cpp
@@ -32,7 +32,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfTcpListener* sfTcpListener_create(void)
+sfTcpListener* sfTcpListener_create()
 {
     return new sfTcpListener;
 }

--- a/src/CSFML/Network/TcpSocket.cpp
+++ b/src/CSFML/Network/TcpSocket.cpp
@@ -34,7 +34,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfTcpSocket* sfTcpSocket_create(void)
+sfTcpSocket* sfTcpSocket_create()
 {
     return new sfTcpSocket;
 }

--- a/src/CSFML/Network/UdpSocket.cpp
+++ b/src/CSFML/Network/UdpSocket.cpp
@@ -34,7 +34,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfUdpSocket* sfUdpSocket_create(void)
+sfUdpSocket* sfUdpSocket_create()
 {
     return new sfUdpSocket;
 }

--- a/src/CSFML/System/Buffer.cpp
+++ b/src/CSFML/System/Buffer.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfBuffer* sfBuffer_create(void)
+sfBuffer* sfBuffer_create()
 {
     return new sfBuffer;
 }

--- a/src/CSFML/System/Clock.cpp
+++ b/src/CSFML/System/Clock.cpp
@@ -32,7 +32,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfClock* sfClock_create(void)
+sfClock* sfClock_create()
 {
     return new sfClock;
 }

--- a/src/CSFML/Window/Context.cpp
+++ b/src/CSFML/Window/Context.cpp
@@ -32,7 +32,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfContext* sfContext_create(void)
+sfContext* sfContext_create()
 {
     return new sfContext;
 }

--- a/src/CSFML/Window/Joystick.cpp
+++ b/src/CSFML/Window/Joystick.cpp
@@ -82,7 +82,7 @@ sfJoystickIdentification sfJoystick_getIdentification(unsigned int joystick)
 }
 
 ////////////////////////////////////////////////////////////
-void sfJoystick_update(void)
+void sfJoystick_update()
 {
     sf::Joystick::update();
 }

--- a/src/CSFML/Window/VideoMode.cpp
+++ b/src/CSFML/Window/VideoMode.cpp
@@ -31,7 +31,7 @@
 
 
 ////////////////////////////////////////////////////////////
-sfVideoMode sfVideoMode_getDesktopMode(void)
+sfVideoMode sfVideoMode_getDesktopMode()
 {
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
     sfVideoMode ret;


### PR DESCRIPTION
This `(void)` is required in C but not in C++ so we can remove these from our .cpp files while keeping them in the .h files.