### PR TITLE
Stop leaving variables unused in release builds

### DIFF
--- a/src/CSFML/Audio/Music.cpp
+++ b/src/CSFML/Audio/Music.cpp
@@ -252,8 +252,7 @@ float sfMusic_getVolume(const sfMusic* music)
 ////////////////////////////////////////////////////////////
 sfVector3f sfMusic_getPosition(const sfMusic* music)
 {
-    sfVector3f position = {0, 0, 0};
-    CSFML_CHECK_RETURN(music, position);
+    CSFML_CHECK_RETURN(music, {});
 
     return convertVector3(music->This.getPosition());
 }

--- a/src/CSFML/Audio/Sound.cpp
+++ b/src/CSFML/Audio/Sound.cpp
@@ -186,8 +186,7 @@ float sfSound_getVolume(const sfSound* sound)
 ////////////////////////////////////////////////////////////
 sfVector3f sfSound_getPosition(const sfSound* sound)
 {
-    sfVector3f position = {0, 0, 0};
-    CSFML_CHECK_RETURN(sound, position);
+    CSFML_CHECK_RETURN(sound, {});
 
     return convertVector3(sound->This.getPosition());
 }

--- a/src/CSFML/Audio/SoundStream.cpp
+++ b/src/CSFML/Audio/SoundStream.cpp
@@ -168,8 +168,7 @@ float sfSoundStream_getVolume(const sfSoundStream* soundStream)
 ////////////////////////////////////////////////////////////
 sfVector3f sfSoundStream_getPosition(const sfSoundStream* soundStream)
 {
-    sfVector3f position = {0, 0, 0};
-    CSFML_CHECK_RETURN(soundStream, position);
+    CSFML_CHECK_RETURN(soundStream, {});
 
     return convertVector3(soundStream->This.getPosition());
 }

--- a/src/CSFML/Graphics/CircleShape.cpp
+++ b/src/CSFML/Graphics/CircleShape.cpp
@@ -92,8 +92,7 @@ void sfCircleShape_setOrigin(sfCircleShape* shape, sfVector2f origin)
 ////////////////////////////////////////////////////////////
 sfVector2f sfCircleShape_getPosition(const sfCircleShape* shape)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(shape, position);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPosition());
 }
@@ -109,8 +108,7 @@ float sfCircleShape_getRotation(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfCircleShape_getScale(const sfCircleShape* shape)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(shape, scale);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getScale());
 }
@@ -119,8 +117,7 @@ sfVector2f sfCircleShape_getScale(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfCircleShape_getOrigin(const sfCircleShape* shape)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(shape, origin);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getOrigin());
 }
@@ -215,8 +212,7 @@ const sfTexture* sfCircleShape_getTexture(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfIntRect sfCircleShape_getTextureRect(const sfCircleShape* shape)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getTextureRect());
 }
@@ -225,8 +221,7 @@ sfIntRect sfCircleShape_getTextureRect(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfCircleShape_getFillColor(const sfCircleShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getFillColor());
 }
@@ -235,8 +230,7 @@ sfColor sfCircleShape_getFillColor(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfCircleShape_getOutlineColor(const sfCircleShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getOutlineColor());
 }
@@ -259,8 +253,7 @@ size_t sfCircleShape_getPointCount(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfCircleShape_getPoint(const sfCircleShape* shape, size_t index)
 {
-    sfVector2f point = {0, 0};
-    CSFML_CHECK_RETURN(shape, point);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPoint(index));
 }
@@ -290,8 +283,7 @@ void sfCircleShape_setPointCount(sfCircleShape* shape, size_t count)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfCircleShape_getLocalBounds(const sfCircleShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getLocalBounds());
 }
@@ -300,8 +292,7 @@ sfFloatRect sfCircleShape_getLocalBounds(const sfCircleShape* shape)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfCircleShape_getGlobalBounds(const sfCircleShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getGlobalBounds());
 }

--- a/src/CSFML/Graphics/ConvexShape.cpp
+++ b/src/CSFML/Graphics/ConvexShape.cpp
@@ -89,8 +89,7 @@ void sfConvexShape_setOrigin(sfConvexShape* shape, sfVector2f origin)
 ////////////////////////////////////////////////////////////
 sfVector2f sfConvexShape_getPosition(const sfConvexShape* shape)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(shape, position);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPosition());
 }
@@ -106,8 +105,7 @@ float sfConvexShape_getRotation(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfConvexShape_getScale(const sfConvexShape* shape)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(shape, scale);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getScale());
 }
@@ -116,8 +114,7 @@ sfVector2f sfConvexShape_getScale(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfConvexShape_getOrigin(const sfConvexShape* shape)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(shape, origin);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getOrigin());
 }
@@ -212,8 +209,7 @@ const sfTexture* sfConvexShape_getTexture(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfIntRect sfConvexShape_getTextureRect(const sfConvexShape* shape)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getTextureRect());
 }
@@ -222,8 +218,7 @@ sfIntRect sfConvexShape_getTextureRect(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfConvexShape_getFillColor(const sfConvexShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getFillColor());
 }
@@ -232,8 +227,7 @@ sfColor sfConvexShape_getFillColor(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfConvexShape_getOutlineColor(const sfConvexShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getOutlineColor());
 }
@@ -256,8 +250,7 @@ size_t sfConvexShape_getPointCount(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfConvexShape_getPoint(const sfConvexShape* shape, size_t index)
 {
-    sfVector2f point = {0, 0};
-    CSFML_CHECK_RETURN(shape, point);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPoint(index));
 }
@@ -280,8 +273,7 @@ void sfConvexShape_setPoint(sfConvexShape* shape, size_t index, sfVector2f point
 ////////////////////////////////////////////////////////////
 sfFloatRect sfConvexShape_getLocalBounds(const sfConvexShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getLocalBounds());
 }
@@ -290,8 +282,7 @@ sfFloatRect sfConvexShape_getLocalBounds(const sfConvexShape* shape)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfConvexShape_getGlobalBounds(const sfConvexShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getGlobalBounds());
 }

--- a/src/CSFML/Graphics/Image.cpp
+++ b/src/CSFML/Graphics/Image.cpp
@@ -160,8 +160,7 @@ void sfImage_setPixel(sfImage* image, unsigned int x, unsigned int y, sfColor co
 ////////////////////////////////////////////////////////////
 sfColor sfImage_getPixel(const sfImage* image, unsigned int x, unsigned int y)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(image, color);
+    CSFML_CHECK_RETURN(image, {});
 
     return convertColor(image->This.getPixel({ x, y }));
 }
@@ -177,8 +176,7 @@ const uint8_t* sfImage_getPixelsPtr(const sfImage* image)
 ////////////////////////////////////////////////////////////
 sfVector2u sfImage_getSize(const sfImage* image)
 {
-    sfVector2u size = {0, 0};
-    CSFML_CHECK_RETURN(image, size);
+    CSFML_CHECK_RETURN(image, {});
 
     return convertVector2(image->This.getSize());
 }

--- a/src/CSFML/Graphics/RectangleShape.cpp
+++ b/src/CSFML/Graphics/RectangleShape.cpp
@@ -89,8 +89,7 @@ void sfRectangleShape_setOrigin(sfRectangleShape* shape, sfVector2f origin)
 ////////////////////////////////////////////////////////////
 sfVector2f sfRectangleShape_getPosition(const sfRectangleShape* shape)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(shape, position);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPosition());
 }
@@ -106,8 +105,7 @@ float sfRectangleShape_getRotation(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfRectangleShape_getScale(const sfRectangleShape* shape)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(shape, scale);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getScale());
 }
@@ -116,8 +114,7 @@ sfVector2f sfRectangleShape_getScale(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfRectangleShape_getOrigin(const sfRectangleShape* shape)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(shape, origin);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getOrigin());
 }
@@ -212,8 +209,7 @@ const sfTexture* sfRectangleShape_getTexture(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfIntRect sfRectangleShape_getTextureRect(const sfRectangleShape* shape)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getTextureRect());
 }
@@ -222,8 +218,7 @@ sfIntRect sfRectangleShape_getTextureRect(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfRectangleShape_getFillColor(const sfRectangleShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getFillColor());
 }
@@ -232,8 +227,7 @@ sfColor sfRectangleShape_getFillColor(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfRectangleShape_getOutlineColor(const sfRectangleShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getOutlineColor());
 }
@@ -256,8 +250,7 @@ size_t sfRectangleShape_getPointCount(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfRectangleShape_getPoint(const sfRectangleShape* shape, size_t index)
 {
-    sfVector2f point = {0, 0};
-    CSFML_CHECK_RETURN(shape, point);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPoint(index));
 }
@@ -273,8 +266,7 @@ void sfRectangleShape_setSize(sfRectangleShape* shape, sfVector2f size)
 ////////////////////////////////////////////////////////////
 sfVector2f sfRectangleShape_getSize(const sfRectangleShape* shape)
 {
-    sfVector2f size = {0, 0};
-    CSFML_CHECK_RETURN(shape, size);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getSize());
 }
@@ -283,8 +275,7 @@ sfVector2f sfRectangleShape_getSize(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfRectangleShape_getLocalBounds(const sfRectangleShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getLocalBounds());
 }
@@ -293,8 +284,7 @@ sfFloatRect sfRectangleShape_getLocalBounds(const sfRectangleShape* shape)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfRectangleShape_getGlobalBounds(const sfRectangleShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getGlobalBounds());
 }

--- a/src/CSFML/Graphics/RenderTexture.cpp
+++ b/src/CSFML/Graphics/RenderTexture.cpp
@@ -73,8 +73,7 @@ void sfRenderTexture_destroy(sfRenderTexture* renderTexture)
 ////////////////////////////////////////////////////////////
 sfVector2u sfRenderTexture_getSize(const sfRenderTexture* renderTexture)
 {
-    sfVector2u size = {0, 0};
-    CSFML_CHECK_RETURN(renderTexture, size);
+    CSFML_CHECK_RETURN(renderTexture, {});
 
     return convertVector2(renderTexture->This.getSize());
 }
@@ -139,9 +138,8 @@ const sfView* sfRenderTexture_getDefaultView(const sfRenderTexture* renderTextur
 ////////////////////////////////////////////////////////////
 sfIntRect sfRenderTexture_getViewport(const sfRenderTexture* renderTexture, const sfView* view)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(view, rect);
-    CSFML_CHECK_RETURN(renderTexture, rect);
+    CSFML_CHECK_RETURN(view, {});
+    CSFML_CHECK_RETURN(renderTexture, {});
 
     return convertRect(renderTexture->This.getViewport(view->This));
 }
@@ -150,8 +148,7 @@ sfIntRect sfRenderTexture_getViewport(const sfRenderTexture* renderTexture, cons
 ////////////////////////////////////////////////////////////
 sfVector2f sfRenderTexture_mapPixelToCoords(const sfRenderTexture* renderTexture, sfVector2i point, const sfView* targetView)
 {
-    sfVector2f result = {0, 0};
-    CSFML_CHECK_RETURN(renderTexture, result);
+    CSFML_CHECK_RETURN(renderTexture, {});
 
     if (targetView)
         return convertVector2(renderTexture->This.mapPixelToCoords(convertVector2(point), targetView->This));
@@ -163,8 +160,7 @@ sfVector2f sfRenderTexture_mapPixelToCoords(const sfRenderTexture* renderTexture
 ////////////////////////////////////////////////////////////
 sfVector2i sfRenderTexture_mapCoordsToPixel(const sfRenderTexture* renderTexture, sfVector2f point, const sfView* targetView)
 {
-    sfVector2i result = {0, 0};
-    CSFML_CHECK_RETURN(renderTexture, result);
+    CSFML_CHECK_RETURN(renderTexture, {});
 
     if (targetView)
         return convertVector2(renderTexture->This.mapCoordsToPixel(convertVector2(point), targetView->This));

--- a/src/CSFML/Graphics/RenderWindow.cpp
+++ b/src/CSFML/Graphics/RenderWindow.cpp
@@ -168,8 +168,7 @@ bool sfRenderWindow_waitEvent(sfRenderWindow* renderWindow, sfEvent* event)
 ////////////////////////////////////////////////////////////
 sfVector2i sfRenderWindow_getPosition(const sfRenderWindow* renderWindow)
 {
-    sfVector2i position = {0, 0};
-    CSFML_CHECK_RETURN(renderWindow, position);
+    CSFML_CHECK_RETURN(renderWindow, {});
 
     return convertVector2(renderWindow->This.getPosition());;
 }
@@ -185,8 +184,7 @@ void sfRenderWindow_setPosition(sfRenderWindow* renderWindow, sfVector2i positio
 ////////////////////////////////////////////////////////////
 sfVector2u sfRenderWindow_getSize(const sfRenderWindow* renderWindow)
 {
-    sfVector2u size = {0, 0};
-    CSFML_CHECK_RETURN(renderWindow, size);
+    CSFML_CHECK_RETURN(renderWindow, {});
 
     return convertVector2(renderWindow->This.getSize());
 }
@@ -360,9 +358,8 @@ const sfView* sfRenderWindow_getDefaultView(const sfRenderWindow* renderWindow)
 ////////////////////////////////////////////////////////////
 sfIntRect sfRenderWindow_getViewport(const sfRenderWindow* renderWindow, const sfView* view)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(view, rect);
-    CSFML_CHECK_RETURN(renderWindow, rect);
+    CSFML_CHECK_RETURN(view, {});
+    CSFML_CHECK_RETURN(renderWindow, {});
 
     return convertRect(renderWindow->This.getViewport(view->This));
 }
@@ -371,8 +368,7 @@ sfIntRect sfRenderWindow_getViewport(const sfRenderWindow* renderWindow, const s
 ////////////////////////////////////////////////////////////
 sfVector2f sfRenderWindow_mapPixelToCoords(const sfRenderWindow* renderWindow, sfVector2i point, const sfView* targetView)
 {
-    sfVector2f result = {0, 0};
-    CSFML_CHECK_RETURN(renderWindow, result);
+    CSFML_CHECK_RETURN(renderWindow, {});
 
     if (targetView)
         return convertVector2(renderWindow->This.mapPixelToCoords(convertVector2(point), targetView->This));
@@ -384,8 +380,7 @@ sfVector2f sfRenderWindow_mapPixelToCoords(const sfRenderWindow* renderWindow, s
 ////////////////////////////////////////////////////////////
 sfVector2i sfRenderWindow_mapCoordsToPixel(const sfRenderWindow* renderWindow, sfVector2f point, const sfView* targetView)
 {
-    sfVector2i result = {0, 0};
-    CSFML_CHECK_RETURN(renderWindow, result);
+    CSFML_CHECK_RETURN(renderWindow, {});
 
     if (targetView)
         return convertVector2(renderWindow->This.mapCoordsToPixel(convertVector2(point), targetView->This));

--- a/src/CSFML/Graphics/Shape.cpp
+++ b/src/CSFML/Graphics/Shape.cpp
@@ -82,8 +82,7 @@ void sfShape_setOrigin(sfShape* shape, sfVector2f origin)
 ////////////////////////////////////////////////////////////
 sfVector2f sfShape_getPosition(const sfShape* shape)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(shape, position);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPosition());
 }
@@ -99,8 +98,7 @@ float sfShape_getRotation(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfShape_getScale(const sfShape* shape)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(shape, scale);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getScale());
 }
@@ -109,8 +107,7 @@ sfVector2f sfShape_getScale(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfShape_getOrigin(const sfShape* shape)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(shape, origin);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getOrigin());
 }
@@ -205,8 +202,7 @@ const sfTexture* sfShape_getTexture(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfIntRect sfShape_getTextureRect(const sfShape* shape)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getTextureRect());
 }
@@ -215,8 +211,7 @@ sfIntRect sfShape_getTextureRect(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfShape_getFillColor(const sfShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getFillColor());
 }
@@ -225,8 +220,7 @@ sfColor sfShape_getFillColor(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfColor sfShape_getOutlineColor(const sfShape* shape)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(shape, color);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertColor(shape->This.getOutlineColor());
 }
@@ -249,8 +243,7 @@ size_t sfShape_getPointCount(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfVector2f sfShape_getPoint(const sfShape* shape, size_t index)
 {
-    sfVector2f point = {0, 0};
-    CSFML_CHECK_RETURN(shape, point);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertVector2(shape->This.getPoint(index));
 }
@@ -259,8 +252,7 @@ sfVector2f sfShape_getPoint(const sfShape* shape, size_t index)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfShape_getLocalBounds(const sfShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getLocalBounds());
 }
@@ -269,8 +261,7 @@ sfFloatRect sfShape_getLocalBounds(const sfShape* shape)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfShape_getGlobalBounds(const sfShape* shape)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(shape, rect);
+    CSFML_CHECK_RETURN(shape, {});
 
     return convertRect(shape->This.getGlobalBounds());
 }

--- a/src/CSFML/Graphics/Sprite.cpp
+++ b/src/CSFML/Graphics/Sprite.cpp
@@ -93,8 +93,7 @@ void sfSprite_setOrigin(sfSprite* sprite, sfVector2f origin)
 ////////////////////////////////////////////////////////////
 sfVector2f sfSprite_getPosition(const sfSprite* sprite)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(sprite, position);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertVector2(sprite->This.getPosition());
 }
@@ -110,8 +109,7 @@ float sfSprite_getRotation(const sfSprite* sprite)
 ////////////////////////////////////////////////////////////
 sfVector2f sfSprite_getScale(const sfSprite* sprite)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(sprite, scale);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertVector2(sprite->This.getScale());
 }
@@ -120,8 +118,7 @@ sfVector2f sfSprite_getScale(const sfSprite* sprite)
 ////////////////////////////////////////////////////////////
 sfVector2f sfSprite_getOrigin(const sfSprite* sprite)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(sprite, origin);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertVector2(sprite->This.getOrigin());
 }
@@ -205,8 +202,7 @@ const sfTexture* sfSprite_getTexture(const sfSprite* sprite)
 ////////////////////////////////////////////////////////////
 sfIntRect sfSprite_getTextureRect(const sfSprite* sprite)
 {
-    sfIntRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(sprite, rect);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertRect(sprite->This.getTextureRect());
 }
@@ -215,8 +211,7 @@ sfIntRect sfSprite_getTextureRect(const sfSprite* sprite)
 ////////////////////////////////////////////////////////////
 sfColor sfSprite_getColor(const sfSprite* sprite)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(sprite, color);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertColor(sprite->This.getColor());
 }
@@ -225,8 +220,7 @@ sfColor sfSprite_getColor(const sfSprite* sprite)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfSprite_getLocalBounds(const sfSprite* sprite)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(sprite, rect);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertRect(sprite->This.getLocalBounds());
 }
@@ -235,8 +229,7 @@ sfFloatRect sfSprite_getLocalBounds(const sfSprite* sprite)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfSprite_getGlobalBounds(const sfSprite* sprite)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(sprite, rect);
+    CSFML_CHECK_RETURN(sprite, {});
 
     return convertRect(sprite->This.getGlobalBounds());
 }

--- a/src/CSFML/Graphics/Text.cpp
+++ b/src/CSFML/Graphics/Text.cpp
@@ -92,8 +92,7 @@ void sfText_setOrigin(sfText* text, sfVector2f origin)
 ////////////////////////////////////////////////////////////
 sfVector2f sfText_getPosition(const sfText* text)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(text, position);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertVector2(text->This.getPosition());
 }
@@ -109,8 +108,7 @@ float sfText_getRotation(const sfText* text)
 ////////////////////////////////////////////////////////////
 sfVector2f sfText_getScale(const sfText* text)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(text, scale);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertVector2(text->This.getScale());
 }
@@ -119,8 +117,7 @@ sfVector2f sfText_getScale(const sfText* text)
 ////////////////////////////////////////////////////////////
 sfVector2f sfText_getOrigin(const sfText* text)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(text, origin);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertVector2(text->This.getOrigin());
 }
@@ -302,8 +299,7 @@ uint32_t sfText_getStyle(const sfText* text)
 ////////////////////////////////////////////////////////////
 sfColor sfText_getFillColor(const sfText* text)
 {
-    sfColor color = {0, 0, 0, 0};
-    CSFML_CHECK_RETURN(text, color);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertColor(text->This.getFillColor());
 }
@@ -312,8 +308,7 @@ sfColor sfText_getFillColor(const sfText* text)
 ////////////////////////////////////////////////////////////
 sfColor sfText_getOutlineColor(const sfText* text)
 {
-    sfColor color = { 0, 0, 0, 0 };
-    CSFML_CHECK_RETURN(text, color);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertColor(text->This.getOutlineColor());
 }
@@ -329,8 +324,7 @@ float sfText_getOutlineThickness(const sfText* text)
 ////////////////////////////////////////////////////////////
 sfVector2f sfText_findCharacterPos(const sfText* text, size_t index)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(text, position);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertVector2(text->This.findCharacterPos(index));
 }
@@ -339,8 +333,7 @@ sfVector2f sfText_findCharacterPos(const sfText* text, size_t index)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfText_getLocalBounds(const sfText* text)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(text, rect);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertRect(text->This.getLocalBounds());
 }
@@ -349,8 +342,7 @@ sfFloatRect sfText_getLocalBounds(const sfText* text)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfText_getGlobalBounds(const sfText* text)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(text, rect);
+    CSFML_CHECK_RETURN(text, {});
 
     return convertRect(text->This.getGlobalBounds());
 }

--- a/src/CSFML/Graphics/Texture.cpp
+++ b/src/CSFML/Graphics/Texture.cpp
@@ -210,8 +210,7 @@ void sfTexture_destroy(sfTexture* texture)
 ////////////////////////////////////////////////////////////
 sfVector2u sfTexture_getSize(const sfTexture* texture)
 {
-    sfVector2u size = {0, 0};
-    CSFML_CHECK_RETURN(texture, size);
+    CSFML_CHECK_RETURN(texture, {});
 
     return convertVector2(texture->This->getSize());
 }

--- a/src/CSFML/Graphics/Transform.cpp
+++ b/src/CSFML/Graphics/Transform.cpp
@@ -76,8 +76,7 @@ sfTransform sfTransform_getInverse(const sfTransform* transform)
 ////////////////////////////////////////////////////////////
 sfVector2f sfTransform_transformPoint(const sfTransform* transform, sfVector2f point)
 {
-    sfVector2f p = {0, 0};
-    CSFML_CHECK_RETURN(transform, p);
+    CSFML_CHECK_RETURN(transform, {});
 
     return convertVector2(convertTransform(*transform).transformPoint(convertVector2(point)));
 }
@@ -86,8 +85,7 @@ sfVector2f sfTransform_transformPoint(const sfTransform* transform, sfVector2f p
 ////////////////////////////////////////////////////////////
 sfFloatRect sfTransform_transformRect(const sfTransform* transform, sfFloatRect rectangle)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(transform, rect);
+    CSFML_CHECK_RETURN(transform, {});
 
     return convertRect(convertTransform(*transform).transformRect(convertRect(rectangle)));
 }

--- a/src/CSFML/Graphics/Transformable.cpp
+++ b/src/CSFML/Graphics/Transformable.cpp
@@ -88,8 +88,7 @@ void sfTransformable_setOrigin(sfTransformable* transformable, sfVector2f origin
 ////////////////////////////////////////////////////////////
 sfVector2f sfTransformable_getPosition(const sfTransformable* transformable)
 {
-    sfVector2f position = {0, 0};
-    CSFML_CHECK_RETURN(transformable, position);
+    CSFML_CHECK_RETURN(transformable, {});
 
     return convertVector2(transformable->This.getPosition());
 }
@@ -105,8 +104,7 @@ float sfTransformable_getRotation(const sfTransformable* transformable)
 ////////////////////////////////////////////////////////////
 sfVector2f sfTransformable_getScale(const sfTransformable* transformable)
 {
-    sfVector2f scale = {0, 0};
-    CSFML_CHECK_RETURN(transformable, scale);
+    CSFML_CHECK_RETURN(transformable, {});
 
     return convertVector2(transformable->This.getScale());
 }
@@ -115,8 +113,7 @@ sfVector2f sfTransformable_getScale(const sfTransformable* transformable)
 ////////////////////////////////////////////////////////////
 sfVector2f sfTransformable_getOrigin(const sfTransformable* transformable)
 {
-    sfVector2f origin = {0, 0};
-    CSFML_CHECK_RETURN(transformable, origin);
+    CSFML_CHECK_RETURN(transformable, {});
 
     return convertVector2(transformable->This.getOrigin());
 }

--- a/src/CSFML/Graphics/VertexArray.cpp
+++ b/src/CSFML/Graphics/VertexArray.cpp
@@ -111,8 +111,7 @@ sfPrimitiveType sfVertexArray_getPrimitiveType(sfVertexArray* vertexArray)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfVertexArray_getBounds(sfVertexArray* vertexArray)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(vertexArray, rect);
+    CSFML_CHECK_RETURN(vertexArray, {});
 
     return convertRect(vertexArray->This.getBounds());
 }

--- a/src/CSFML/Graphics/View.cpp
+++ b/src/CSFML/Graphics/View.cpp
@@ -93,8 +93,7 @@ void sfView_setViewport(sfView* view, sfFloatRect viewport)
 ////////////////////////////////////////////////////////////
 sfVector2f sfView_getCenter(const sfView* view)
 {
-    sfVector2f center = {0, 0};
-    CSFML_CHECK_RETURN(view, center);
+    CSFML_CHECK_RETURN(view, {});
 
     return convertVector2(view->This.getCenter());
 }
@@ -103,8 +102,7 @@ sfVector2f sfView_getCenter(const sfView* view)
 ////////////////////////////////////////////////////////////
 sfVector2f sfView_getSize(const sfView* view)
 {
-    sfVector2f size = {0, 0};
-    CSFML_CHECK_RETURN(view, size);
+    CSFML_CHECK_RETURN(view, {});
 
     return convertVector2(view->This.getSize());
 }
@@ -120,8 +118,7 @@ float sfView_getRotation(const sfView* view)
 ////////////////////////////////////////////////////////////
 sfFloatRect sfView_getViewport(const sfView* view)
 {
-    sfFloatRect rect = {{0, 0}, {0, 0}};
-    CSFML_CHECK_RETURN(view, rect);
+    CSFML_CHECK_RETURN(view, {});
 
     return convertRect(view->This.getViewport());
 }

--- a/src/CSFML/Internal.hpp
+++ b/src/CSFML/Internal.hpp
@@ -115,20 +115,13 @@
     #define CSFML_CALL_PTR(object_, function_) \
         ((object_)->This->function_)
 
-    #define CSFML_CHECK_RETURN(object_, default_) \
-        (void)(default_);
+    #define CSFML_CHECK_RETURN(object_, default_)
 
     #define CSFML_CALL_RETURN(object_, function_, default_) \
-        { \
-            (void)(default_); \
-            return ((object_)->This.function_); \
-        }
+        return ((object_)->This.function_);
 
     #define CSFML_CALL_PTR_RETURN(object_, function_, default_) \
-        { \
-            (void)(default_); \
-            return ((object_)->This->function_); \
-        }
+        return ((object_)->This->function_);
 
 #endif
 

--- a/src/CSFML/Window/Window.cpp
+++ b/src/CSFML/Window/Window.cpp
@@ -148,8 +148,7 @@ bool sfWindow_waitEvent(sfWindow* window, sfEvent* event)
 ////////////////////////////////////////////////////////////
 sfVector2i sfWindow_getPosition(const sfWindow* window)
 {
-    sfVector2i position = {0, 0};
-    CSFML_CHECK_RETURN(window, position);
+    CSFML_CHECK_RETURN(window, {});
 
     return convertVector2(window->This.getPosition());
 }
@@ -165,8 +164,7 @@ void sfWindow_setPosition(sfWindow* window, sfVector2i position)
 ////////////////////////////////////////////////////////////
 sfVector2u sfWindow_getSize(const sfWindow* window)
 {
-    sfVector2u size = {0, 0};
-    CSFML_CHECK_RETURN(window, size);
+    CSFML_CHECK_RETURN(window, {});
 
     return convertVector2(window->This.getSize());
 }

--- a/src/CSFML/Window/WindowBase.cpp
+++ b/src/CSFML/Window/WindowBase.cpp
@@ -132,8 +132,7 @@ bool sfWindowBase_waitEvent(sfWindowBase* windowBase, sfEvent* event)
 ////////////////////////////////////////////////////////////
 sfVector2i sfWindowBase_getPosition(const sfWindowBase* windowBase)
 {
-    sfVector2i position = {0, 0};
-    CSFML_CHECK_RETURN(windowBase, position);
+    CSFML_CHECK_RETURN(windowBase, {});
 
     return convertVector2(windowBase->This.getPosition());
 }
@@ -149,8 +148,7 @@ void sfWindowBase_setPosition(sfWindowBase* windowBase, sfVector2i position)
 ////////////////////////////////////////////////////////////
 sfVector2u sfWindowBase_getSize(const sfWindowBase* windowBase)
 {
-    sfVector2u size = {0, 0};
-    CSFML_CHECK_RETURN(windowBase, size);
+    CSFML_CHECK_RETURN(windowBase, {});
 
     return convertVector2(windowBase->This.getSize());
 }


### PR DESCRIPTION
In a Release build, macros like `CSFML_CHECK_RETURN` expand into nothing more than a cast-to-void which is meant to silence compiler warnings about unused variables.
    
By declaring a temporary inside the macro argument, we ensure that debug builds behave the same as always but Release builds expand these macros into truly no code thus ensuring these temporary variables are never created in the first place so there is now nothing that we have to cast to void.