### PR TITLE
Put common configuration settings in a CMakePresets file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         path: SFML
 
     - name: Configure SFML CMake
-      run: cmake -S SFML -B SFML/build -DCMAKE_INSTALL_PREFIX=SFML/install -DBUILD_SHARED_LIBS=TRUE -DSFML_BUILD_EXAMPLES=FALSE -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
+      run: cmake -S SFML -B SFML/build -DCMAKE_INSTALL_PREFIX=SFML/install -DBUILD_SHARED_LIBS=TRUE ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build SFML
       run: cmake --build SFML/build --config ${{matrix.type.name}} --target install
@@ -61,7 +61,7 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      run: cmake -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DBUILD_SHARED_LIBS=TRUE -DCSFML_BUILD_EXAMPLES=TRUE -DCSFML_BUILD_TEST_SUITE=TRUE -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON -DWARNINGS_AS_ERRORS=TRUE ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
+      run: cmake --preset dev -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build CSFML
       run: cmake --build CSFML/build --config ${{matrix.type.name}} --target install
@@ -113,7 +113,7 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      run: cmake -S CSFML -B CSFML/build -DBUILD_SHARED_LIBS=TRUE -DCSFML_BUILD_EXAMPLES=TRUE -DCSFML_BUILD_TEST_SUITE=TRUE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
+      run: cmake --preset dev -S CSFML -B CSFML/build -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_BUILD_TYPE=Debug
 
     - name: Tidy
       run: cmake --build CSFML/build --target tidy

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,18 @@
+{
+  "version": 3,
+  "configurePresets":[
+    {
+      "name": "dev",
+      "binaryDir": "build",
+      "installDir": "${sourceDir}/build/install",
+      "cacheVariables": {
+        "CMAKE_C_EXTENSIONS": "OFF",
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CSFML_BUILD_EXAMPLES": "ON",
+        "CSFML_BUILD_TEST_SUITE": "ON",
+        "WARNINGS_AS_ERRORS": "ON"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This `dev` preset aims to be equivalent to SFML's `dev` preset. I also removed some redundant configuration flags from CI.