### PR TITLE
Use `SFML_ROOT` to find SFML installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      run: cmake --preset dev -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
+      run: cmake --preset dev -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_ROOT=SFML/install -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build CSFML
       run: cmake --build CSFML/build --config ${{matrix.type.name}} --target install
@@ -113,7 +113,7 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      run: cmake --preset dev -S CSFML -B CSFML/build -DSFML_DIR=$GITHUB_WORKSPACE/SFML/install/lib/cmake/SFML -DCMAKE_BUILD_TYPE=Debug
+      run: cmake --preset dev -S CSFML -B CSFML/build -DSFML_ROOT=SFML/install -DCMAKE_BUILD_TYPE=Debug
 
     - name: Tidy
       run: cmake --build CSFML/build --target tidy

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Of course, you can also find the CSFML API documentation in the SDK.
 
 ## Building
 
-Set `SFML_DIR` to a directory containing the `SFMLConfig.cmake` file, usually located at `lib/cmake/SFML`.
+Set `SFML_ROOT` to a directory containing the installation of SFML.
 
 ## Contribute
 

--- a/tools/BuildMacOS.sh
+++ b/tools/BuildMacOS.sh
@@ -371,7 +371,7 @@ build_csfml () # $1: 'clang' => clang & libc++
           -D "CMAKE_OSX_DEPLOYMENT_TARGET:STRING=$target" \
           -D "CMAKE_OSX_SYSROOT:STRING=$sdk" \
           -D "BUILD_DOC:BOOL=$doc" \
-          -D "SFML_DIR:PATH=$sfml_package1070/Frameworks/SFML.framework/Versions/$gittag/Resources/CMake" \
+          -D "SFML_ROOT:PATH=$sfml_package1070/Frameworks/SFML.framework/Versions/$gittag/Resources/CMake" \
           "$codedir"
     assert $? "CMake failed"
 

--- a/tools/nuget/build.linux.sh
+++ b/tools/nuget/build.linux.sh
@@ -113,7 +113,7 @@ CSFMLLibDir="$(realpath lib)" # The directory that contains the final CSFML libr
 
 cmake -E env LDFLAGS="-z origin" \
     cmake \
-    "-DSFML_DIR=$SFMLBuiltDir" \
+    "-DSFML_ROOT=$SFMLBuiltDir" \
     '-DBUILD_SHARED_LIBS=1' \
     '-DCMAKE_BUILD_TYPE=Release' \
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$CSFMLLibDir" \

--- a/tools/nuget/build.macos.sh
+++ b/tools/nuget/build.macos.sh
@@ -133,7 +133,7 @@ CSFMLLibDir="$(realpath lib)" # The directory that contains the final CSFML libr
 
 cmake -E env \
     cmake -G "Unix Makefiles" \
-          -D "SFML_DIR=$SFMLBuiltDir" \
+          -D "SFML_ROOT=$SFMLBuiltDir" \
           -D 'BUILD_SHARED_LIBS=ON' \
           -D 'CMAKE_BUILD_TYPE=Release' \
           -D "CMAKE_OSX_ARCHITECTURES=$ARCHITECTURE" \

--- a/tools/nuget/build.win.ps1
+++ b/tools/nuget/build.win.ps1
@@ -141,7 +141,7 @@ New-Item -ItemType Directory lib > $null
 $CSFMLLibDir = (Get-Item lib).FullName; # The directory where the final CSFML dlls are located
 
 cmake `
-    "-DSFML_DIR=$SFMLBuiltDir" `
+    "-DSFML_ROOT=$SFMLBuiltDir" `
     '-DCSFML_LINK_SFML_STATICALLY=1' `
     "-DCMAKE_LIBRARY_PATH=$SFMLExtLibs" `
     `


### PR DESCRIPTION
This is line with modern CMake convention where `-D<PackageName>_ROOT` is used to locate a given package's installation.

https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html#variable:%3CPackageName%3E_ROOT

SFML already uses this convention. See https://github.com/SFML/SFML/commit/30a986e63261eea3ae90e5d16b5b894f2f712403