### PR TITLE
Copy SFML DLLs alongside test executables

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,6 +9,7 @@
         "CMAKE_C_EXTENSIONS": "OFF",
         "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/bin",
         "CSFML_BUILD_EXAMPLES": "ON",
         "CSFML_BUILD_TEST_SUITE": "ON",
         "CSFML_WARNINGS_AS_ERRORS": "ON"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,10 @@ catch_discover_tests(test-csfml-network)
 
 # Copy DLLs into the same directory
 if(SFML_OS_WINDOWS AND NOT CSFML_LINK_SFML_STATICALLY)
-    add_custom_command(TARGET test-csfml-system  POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-system>  $<TARGET_FILE_DIR:test-csfml-system> COMMAND_EXPAND_LISTS)
-    add_custom_command(TARGET test-csfml-window  POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-window>  $<TARGET_FILE_DIR:test-csfml-window> COMMAND_EXPAND_LISTS)
-    add_custom_command(TARGET test-csfml-network POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:test-csfml-network> $<TARGET_FILE_DIR:test-csfml-network> COMMAND_EXPAND_LISTS)
+    foreach(SFML_TARGET SFML::System SFML::Window SFML::Graphics SFML::Audio SFML::Network)
+        add_custom_command(
+            TARGET test-csfml-system PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SFML_TARGET}> $<TARGET_FILE_DIR:test-csfml-system> COMMAND_EXPAND_LISTS
+        )
+    endforeach()
 endif()


### PR DESCRIPTION
For reasons I don't entirely understand, it's possible for the build to fail when trying to copy DLLs into the same directory as the test executable. This problem was recreated locally by Kimci86 but never affected CSFML's CI pipeline until some time after #291 was merged which added even more DLLs into the mix being copied.

This fix uses a more straightforward solution to address DLL issues. The `CMAKE_RUNTIME_OUTPUT_DIRECTORY` variable is used to ensure all EXEs and DLLs built within this project are placed into the same directory. However SFML still has 5 more DLLs to copy so I use a loop to create five more commands that copy those DLLs one by one into the same directory as the rest of the EXEs and DLLs.

For now we only strictly need the DLLs for the System, Window, and Network modules but in the future I hope to add tests for Graphics and Audio so I thought it was reasonable to go ahead and copy those DLLs as well.