### PR TITLE
Add missing `sf` prefix

### DIFF
--- a/include/CSFML/Window/Context.h
+++ b/include/CSFML/Window/Context.h
@@ -32,7 +32,7 @@
 #include <CSFML/Window/Types.h>
 #include <CSFML/Window/Window.h>
 
-typedef void (*GlFunctionPointer)(void);
+typedef void (*sfGlFunctionPointer)(void);
 
 ////////////////////////////////////////////////////////////
 /// \brief Create a new context
@@ -81,7 +81,7 @@ CSFML_WINDOW_API bool sfContext_setActive(sfContext* context, bool active);
 /// \return Address of the OpenGL function, 0 on failure
 ///
 ////////////////////////////////////////////////////////////
-CSFML_WINDOW_API GlFunctionPointer sfContext_getFunction(const char* name);
+CSFML_WINDOW_API sfGlFunctionPointer sfContext_getFunction(const char* name);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the settings of the context.

--- a/src/CSFML/Window/Context.cpp
+++ b/src/CSFML/Window/Context.cpp
@@ -60,7 +60,7 @@ bool sfContext_setActive(sfContext* context, bool active)
 
 
 ////////////////////////////////////////////////////////////
-GlFunctionPointer sfContext_getFunction(const char* name)
+sfGlFunctionPointer sfContext_getFunction(const char* name)
 {
     return sf::Context::getFunction(name);
 }


### PR DESCRIPTION
This function pointer is within the `sf::` namespace of SFML so it ought to have an `sf` prefix in CSFML.