### PR TITLE
Revert "Remove unnecessary `extern` from C function declarations"

### DIFF
--- a/include/CSFML/Config.h
+++ b/include/CSFML/Config.h
@@ -46,7 +46,7 @@
 #ifdef __cplusplus
 #define CSFML_EXTERN_C extern "C"
 #else
-#define CSFML_EXTERN_C
+#define CSFML_EXTERN_C extern
 #endif
 
 


### PR DESCRIPTION
This reverts commit dfaebc6b887e3c1b87af76f9e1d00b2dd23bb7bd.

We still need to make sure `extern` is applied to the variables we export from the interface as is the case with `sfColor` constants, for example. For whatever reason this doesn't cause the tests to fail so I can't demonstrate a failure due to the lack of `extern` but for the sake of caution I'm reverting my previous commit.