### PR TITLE
Support building CSFML as static libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   build:
-    name: ${{ matrix.platform.name }} ${{ matrix.type.name }}
+    name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
@@ -28,6 +28,9 @@ jobs:
         - { name: Linux GCC,           os: ubuntu-22.04, flags: -GNinja }
         - { name: Linux Clang,         os: ubuntu-22.04, flags: -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS,               os: macos-14,     flags: -GNinja }
+        config:
+        - { name: Shared, flags: -DBUILD_SHARED_LIBS=ON,  csfml_flags: -DCSFML_LINK_SFML_STATICALLY=OFF }
+        - { name: Static, flags: -DBUILD_SHARED_LIBS=OFF, csfml_flags: -DCSFML_LINK_SFML_STATICALLY=ON }
         type:
         - { name: Debug }
         - { name: Release }
@@ -50,7 +53,7 @@ jobs:
         path: SFML
 
     - name: Configure SFML CMake
-      run: cmake -S SFML -B SFML/build -DCMAKE_INSTALL_PREFIX=SFML/install -DBUILD_SHARED_LIBS=TRUE ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
+      run: cmake -S SFML -B SFML/build -DCMAKE_INSTALL_PREFIX=SFML/install ${{matrix.platform.flags}} ${{matrix.config.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build SFML
       run: cmake --build SFML/build --config ${{matrix.type.name}} --target install
@@ -61,7 +64,7 @@ jobs:
         path: CSFML
 
     - name: Configure CSFML CMake
-      run: cmake --preset dev -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DCSFML_LINK_SFML_STATICALLY=FALSE -DSFML_ROOT=SFML/install -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
+      run: cmake --preset dev -S CSFML -B CSFML/build -DCMAKE_INSTALL_PREFIX=CSFML/install -DSFML_ROOT=SFML/install -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.config.csfml_flags}} -DCMAKE_BUILD_TYPE=${{matrix.type.name}}
 
     - name: Build CSFML
       run: cmake --build CSFML/build --config ${{matrix.type.name}} --target install

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -27,12 +27,17 @@ macro(csfml_add_library target)
     string(TOUPPER "${NAME_UPPER}" NAME_UPPER)
     set_target_properties(${target} PROPERTIES DEFINE_SYMBOL ${NAME_UPPER}_EXPORTS)
 
-    if(SFML_OS_WINDOWS)
-        # include the major version number in Windows shared library names (but not import library names)
+    if(BUILD_SHARED_LIBS)
         set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
-        set_target_properties(${target} PROPERTIES SUFFIX "-${PROJECT_VERSION_MAJOR}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        if(SFML_OS_WINDOWS)
+            # include the major version number in Windows shared library names (but not import library names)
+            set_target_properties(${target} PROPERTIES SUFFIX "-${PROJECT_VERSION_MAJOR}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        endif()
     else()
-        set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
+        set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -s-d)
+        set_target_properties(${target} PROPERTIES RELEASE_POSTFIX -s)
+        set_target_properties(${target} PROPERTIES MINSIZEREL_POSTFIX -s)
+        set_target_properties(${target} PROPERTIES RELWITHDEBINFO_POSTFIX -s)
     endif()
     if (SFML_OS_WINDOWS AND SFML_COMPILER_GCC)
         # on Windows/gcc get rid of "lib" prefix for shared libraries,
@@ -74,5 +79,10 @@ macro(csfml_add_library target)
             RUNTIME DESTINATION bin COMPONENT bin
             LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT bin
             ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT devel)
+
+    # define CSFML_STATIC if the build type is not set to 'shared'
+    if(NOT BUILD_SHARED_LIBS)
+        target_compile_definitions(${target} PUBLIC CSFML_STATIC)
+    endif()
 
 endmacro()

--- a/include/CSFML/Config.h
+++ b/include/CSFML/Config.h
@@ -84,6 +84,8 @@
 ////////////////////////////////////////////////////////////
 // Define helpers to create portable import / export macros for each module
 ////////////////////////////////////////////////////////////
+#if !defined(CSFML_STATIC)
+
 #if defined(CSFML_SYSTEM_WINDOWS)
 
 // Windows compilers need specific (and different) keywords for export and import
@@ -101,6 +103,14 @@
 
 #define CSFML_API_EXPORT extern "C" __attribute__((__visibility__("default")))
 #define CSFML_API_IMPORT CSFML_EXTERN_C __attribute__((__visibility__("default")))
+
+#endif
+
+#else
+
+// Static build doesn't need import/export macros
+#define CSFML_API_EXPORT extern "C"
+#define CSFML_API_IMPORT CSFML_EXTERN_C
 
 #endif
 


### PR DESCRIPTION
Some languages can make use of C foreign function interfaces compiled as static libraries so it's a good idea for CSFML to support this use case.

Closes #309 