### PR TITLE
Enforce variable and parameter casing style

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
   clang-analyzer-*,
   cppcoreguidelines-*,
   modernize-*,
+  readability-identifier-naming,
   -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,
   -clang-analyzer-core.NonNullParamChecker,
@@ -26,6 +27,10 @@ Checks: >
   -modernize-redundant-void-arg,
   -modernize-use-trailing-return-type,
   -modernize-use-using,
+CheckOptions:
+  - { key: readability-identifier-naming.VariableCase,        value: camelBack }
+  - { key: readability-identifier-naming.GlobalVariableCase,  value: aNy_CasE }
+  - { key: readability-identifier-naming.ParameterCase,       value: camelBack }
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'
 UseColor: true

--- a/src/CSFML/Graphics/Font.cpp
+++ b/src/CSFML/Graphics/Font.cpp
@@ -90,12 +90,12 @@ sfGlyph sfFont_getGlyph(const sfFont* font, uint32_t codePoint, unsigned int cha
 {
     assert(font);
 
-    sf::Glyph SFMLGlyph = font->This.getGlyph(codePoint, characterSize, bold, outlineThickness);
+    sf::Glyph sfmlGlyph = font->This.getGlyph(codePoint, characterSize, bold, outlineThickness);
 
     sfGlyph glyph{};
-    glyph.advance     = SFMLGlyph.advance;
-    glyph.bounds      = convertRect(SFMLGlyph.bounds);
-    glyph.textureRect = convertRect(SFMLGlyph.textureRect);
+    glyph.advance     = sfmlGlyph.advance;
+    glyph.bounds      = convertRect(sfmlGlyph.bounds);
+    glyph.textureRect = convertRect(sfmlGlyph.textureRect);
 
     return glyph;
 }

--- a/src/CSFML/Graphics/Text.cpp
+++ b/src/CSFML/Graphics/Text.cpp
@@ -177,8 +177,8 @@ void sfText_setString(sfText* text, const char* string)
 void sfText_setUnicodeString(sfText* text, const sfChar32* string)
 {
     assert(text);
-    sf::String UTF32Text = reinterpret_cast<const char32_t*>(string);
-    text->This.setString(UTF32Text);
+    sf::String utf32Text = reinterpret_cast<const char32_t*>(string);
+    text->This.setString(utf32Text);
 }
 
 

--- a/src/CSFML/Network/Ftp.cpp
+++ b/src/CSFML/Network/Ftp.cpp
@@ -203,12 +203,12 @@ sfFtpResponse* sfFtp_connect(sfFtp* ftp, sfIpAddress server, unsigned short port
 {
     assert(ftp);
 
-    std::optional<sf::IpAddress> SFMLServer = sf::IpAddress::resolve(server.address);
+    std::optional<sf::IpAddress> sfmlServer = sf::IpAddress::resolve(server.address);
 
-    if (!SFMLServer)
+    if (!sfmlServer)
         return nullptr;
 
-    return new sfFtpResponse{ftp->This.connect(*SFMLServer, port, sf::microseconds(timeout.microseconds))};
+    return new sfFtpResponse{ftp->This.connect(*sfmlServer, port, sf::microseconds(timeout.microseconds))};
 }
 
 


### PR DESCRIPTION
I'm not sure if we can enforce anything else. Function names use a pattern too complicated for clang-tidy to understand. Member variable names use `UpperCase` in the implementation but `lowerCase` in the interface. This may be as far as we can go with `readability-identifier-naming`.