### PR TITLE
Use modern CMake property to handle static runtime linking with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,17 +47,6 @@ csfml_set_option(CSFML_LINK_SFML_STATICALLY ${LINK_STATICALLY_DEFAULT} BOOL "TRU
 # define an option for choosing between static and dynamic C runtime (Windows only)
 if(SFML_OS_WINDOWS)
     set(STATIC_STD_LIBS FALSE CACHE BOOL "TRUE to statically link to the standard libraries, FALSE to use them as DLLs")
-
-    # for VC++, we can apply it globally by modifying the compiler flags
-    if(SFML_COMPILER_MSVC AND STATIC_STD_LIBS)
-        foreach(flag
-                CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-                CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(${flag} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-            endif()
-        endforeach()
-    endif()
 endif()
 
 # find SFML libraries (C++)

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -32,18 +32,23 @@ macro(csfml_add_library target)
         if(SFML_OS_WINDOWS)
             # include the major version number in Windows shared library names (but not import library names)
             set_target_properties(${target} PROPERTIES SUFFIX "-${PROJECT_VERSION_MAJOR}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+            # on Windows/gcc get rid of "lib" prefix for shared libraries,
+            # and transform the ".dll.a" suffix into ".a" for import libraries
+            if (SFML_COMPILER_GCC OR SFML_COMPILER_CLANG)
+                set_target_properties(${target} PROPERTIES PREFIX "")
+                set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
+            endif()
         endif()
     else()
         set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -s-d)
         set_target_properties(${target} PROPERTIES RELEASE_POSTFIX -s)
         set_target_properties(${target} PROPERTIES MINSIZEREL_POSTFIX -s)
         set_target_properties(${target} PROPERTIES RELWITHDEBINFO_POSTFIX -s)
-    endif()
-    if (SFML_OS_WINDOWS AND SFML_COMPILER_GCC)
-        # on Windows/gcc get rid of "lib" prefix for shared libraries,
-        # and transform the ".dll.a" suffix into ".a" for import libraries
-        set_target_properties(${target} PROPERTIES PREFIX "")
-        set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
+
+        if(STATIC_STD_LIBS)
+            set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        endif()
     endif()
 
     # set the version and soversion of the target (for compatible systems -- mostly Linuxes)


### PR DESCRIPTION
See https://github.com/SFML/SFML/pull/1834

Confirmation that this works: https://github.com/SFML/CSFML/issues/309#issuecomment-2336535661