### PR TITLE
Fix NuGet Build for `master`

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -136,7 +136,7 @@ jobs:
         name: Linux MUSL x64
         runs-on: ubuntu-22.04
         container:
-            image: alpine:3.15
+            image: alpine:3.20.3
 
         steps:
             - name: Checkout CSFML

--- a/tools/nuget/build.linux.sh
+++ b/tools/nuget/build.linux.sh
@@ -88,15 +88,16 @@ SFMLLibDir="$(realpath lib)"
 
 cmake -E env LDFLAGS="-z origin" \
     cmake \
-    '-DBUILD_SHARED_LIBS=1' \
+    '-DBUILD_SHARED_LIBS=ON' \
     '-DCMAKE_BUILD_TYPE=Release' \
+    "-DCMAKE_INSTALL_PREFIX=$SFMLLibDir" \
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$SFMLLibDir" \
-    '-DCMAKE_BUILD_WITH_INSTALL_RPATH=1' \
+    '-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON' \
     '-DCMAKE_INSTALL_RPATH=$ORIGIN' \
-    '-DSFML_BUILD_NETWORK=0' \
+    '-DSFML_BUILD_NETWORK=OFF' \
     "$SFMLDir"
 
-cmake --build . --config Release
+cmake --build . --config Release --target install
 
 popd # Pop SFML
 
@@ -113,13 +114,13 @@ CSFMLLibDir="$(realpath lib)" # The directory that contains the final CSFML libr
 
 cmake -E env LDFLAGS="-z origin" \
     cmake \
-    "-DSFML_ROOT=$SFMLBuiltDir" \
-    '-DBUILD_SHARED_LIBS=1' \
+    "-DSFML_ROOT=$SFMLLibDir" \
+    '-DBUILD_SHARED_LIBS=ON' \
     '-DCMAKE_BUILD_TYPE=Release' \
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$CSFMLLibDir" \
-    '-DCMAKE_BUILD_WITH_INSTALL_RPATH=1' \
+    '-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON' \
     '-DCMAKE_INSTALL_RPATH=$ORIGIN' \
-    '-DCSFML_BUILD_NETWORK=0' \
+    '-DCSFML_BUILD_NETWORK=OFF' \
     "$CSFMLDir"
 cmake --build . --config Release
 

--- a/tools/nuget/build.macos.sh
+++ b/tools/nuget/build.macos.sh
@@ -133,7 +133,7 @@ CSFMLLibDir="$(realpath lib)" # The directory that contains the final CSFML libr
 
 cmake -E env \
     cmake -G "Unix Makefiles" \
-          -D "SFML_ROOT=$SFMLBuiltDir" \
+          -D "SFML_ROOT=$SFMLLibDir" \
           -D 'BUILD_SHARED_LIBS=ON' \
           -D 'CMAKE_BUILD_TYPE=Release' \
           -D "CMAKE_OSX_ARCHITECTURES=$ARCHITECTURE" \

--- a/tools/nuget/docker.fedora-x64.sh
+++ b/tools/nuget/docker.fedora-x64.sh
@@ -9,6 +9,7 @@ dnf install -y \
     xorg-x11-server-devel \
     libXrandr-devel \
     libXcursor-devel \
+    libXi-devel \
     systemd-devel \
     mesa-libEGL-devel \
     flac-devel \

--- a/tools/nuget/docker.linux-musl-x64.sh
+++ b/tools/nuget/docker.linux-musl-x64.sh
@@ -11,12 +11,12 @@ apk add \
     libx11-dev \
     libxrandr-dev \
     libxcursor-dev \
+    libxi-dev \
     eudev-dev \
     mesa-dev \
     flac-dev \
     libogg-dev \
     libvorbis-dev \
-    libpthread-stubs \
     cmake \
     make \
     g++


### PR DESCRIPTION
Closes #314 

- Update Alpine image to get the newer CMake version
- Add missing Fedora dependency
- Fix macOS & Linux build not finding SFML
- Build & include SFML as shared library on Windows

Build was successful: https://github.com/eXpl0it3r/CSFML/actions/runs/10762536014

Would still need a bit of testing, if the new packaging for Windows works properly, but that can happen later on.