### PR TITLE
Stop using deprecated `DOXYGEN_EXECUTABLE` variable

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -39,7 +39,7 @@ configure_file(${DOXYGEN_INPUT_DIR}/doc/searchOverrides.css ${DOXYGEN_OUTPUT_DIR
 # target setup
 add_custom_target(doc ALL
                   COMMAND ${CMAKE_COMMAND} -E echo_append "Building API Documentation..."
-                  COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIGURED_INPUT}
+                  COMMAND Doxygen::doxygen ${DOXYGEN_CONFIGURED_INPUT}
                   COMMAND ${CMAKE_COMMAND} -E echo "Done."
                   WORKING_DIRECTORY ${DOXYGEN_INPUT_DIR})
 


### PR DESCRIPTION
This was deprecated in CMake 3.9.

See https://cmake.org/cmake/help/v3.22/module/FindDoxygen.html#variable:DOXYGEN_EXECUTABLE