### PR TITLE
Improve const correctness of `_destroy` functions

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -12,7 +12,7 @@ int main(void)
         return EXIT_FAILURE;
 
     // Load a sprite to display
-    sfTexture* texture = sfTexture_createFromFile("sfml_logo.png", NULL);
+    const sfTexture* texture = sfTexture_createFromFile("sfml_logo.png", NULL);
     if (!texture)
     {
         sfRenderWindow_destroy(window);
@@ -23,7 +23,7 @@ int main(void)
     sfSprite_setPosition(sprite, spritePosition);
 
     // Create a graphical text to display
-    sfFont* font = sfFont_createFromFile("tuffy.ttf");
+    const sfFont* font = sfFont_createFromFile("tuffy.ttf");
     if (!font)
     {
         sfSprite_destroy(sprite);

--- a/include/CSFML/Audio/Music.h
+++ b/include/CSFML/Audio/Music.h
@@ -104,7 +104,7 @@ CSFML_AUDIO_API sfMusic* sfMusic_createFromStream(sfInputStream* stream);
 /// \param music Music to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API void sfMusic_destroy(sfMusic* music);
+CSFML_AUDIO_API void sfMusic_destroy(const sfMusic* music);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set whether or not a music should loop after reaching the end

--- a/include/CSFML/Audio/Sound.h
+++ b/include/CSFML/Audio/Sound.h
@@ -61,7 +61,7 @@ CSFML_AUDIO_API sfSound* sfSound_copy(const sfSound* sound);
 /// \param sound Sound to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API void sfSound_destroy(sfSound* sound);
+CSFML_AUDIO_API void sfSound_destroy(const sfSound* sound);
 
 ////////////////////////////////////////////////////////////
 /// \brief Start or resume playing a sound

--- a/include/CSFML/Audio/SoundBuffer.h
+++ b/include/CSFML/Audio/SoundBuffer.h
@@ -120,7 +120,7 @@ CSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_copy(const sfSoundBuffer* soundBuff
 /// \param soundBuffer Sound buffer to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API void sfSoundBuffer_destroy(sfSoundBuffer* soundBuffer);
+CSFML_AUDIO_API void sfSoundBuffer_destroy(const sfSoundBuffer* soundBuffer);
 
 ////////////////////////////////////////////////////////////
 /// \brief Save a sound buffer to an audio file

--- a/include/CSFML/Audio/SoundBufferRecorder.h
+++ b/include/CSFML/Audio/SoundBufferRecorder.h
@@ -46,7 +46,7 @@ CSFML_AUDIO_API sfSoundBufferRecorder* sfSoundBufferRecorder_create(void);
 /// \param soundBufferRecorder Sound buffer recorder to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API void sfSoundBufferRecorder_destroy(sfSoundBufferRecorder* soundBufferRecorder);
+CSFML_AUDIO_API void sfSoundBufferRecorder_destroy(const sfSoundBufferRecorder* soundBufferRecorder);
 
 ////////////////////////////////////////////////////////////
 /// \brief Start the capture of a sound recorder recorder

--- a/include/CSFML/Audio/SoundRecorder.h
+++ b/include/CSFML/Audio/SoundRecorder.h
@@ -62,7 +62,7 @@ CSFML_AUDIO_API sfSoundRecorder* sfSoundRecorder_create(sfSoundRecorderStartCall
 /// \param soundRecorder Sound recorder to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API void sfSoundRecorder_destroy(sfSoundRecorder* soundRecorder);
+CSFML_AUDIO_API void sfSoundRecorder_destroy(const sfSoundRecorder* soundRecorder);
 
 ////////////////////////////////////////////////////////////
 /// \brief Start the capture of a sound recorder

--- a/include/CSFML/Audio/SoundStream.h
+++ b/include/CSFML/Audio/SoundStream.h
@@ -81,7 +81,7 @@ CSFML_AUDIO_API sfSoundStream* sfSoundStream_create(
 /// \param soundStream Sound stream to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API void sfSoundStream_destroy(sfSoundStream* soundStream);
+CSFML_AUDIO_API void sfSoundStream_destroy(const sfSoundStream* soundStream);
 
 ////////////////////////////////////////////////////////////
 /// \brief Start or resume playing a sound stream

--- a/include/CSFML/Graphics/CircleShape.h
+++ b/include/CSFML/Graphics/CircleShape.h
@@ -62,7 +62,7 @@ CSFML_GRAPHICS_API sfCircleShape* sfCircleShape_copy(const sfCircleShape* shape)
 /// \param shape Shape to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfCircleShape_destroy(sfCircleShape* shape);
+CSFML_GRAPHICS_API void sfCircleShape_destroy(const sfCircleShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a circle shape

--- a/include/CSFML/Graphics/ConvexShape.h
+++ b/include/CSFML/Graphics/ConvexShape.h
@@ -62,7 +62,7 @@ CSFML_GRAPHICS_API sfConvexShape* sfConvexShape_copy(const sfConvexShape* shape)
 /// \param shape Shape to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfConvexShape_destroy(sfConvexShape* shape);
+CSFML_GRAPHICS_API void sfConvexShape_destroy(const sfConvexShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a convex shape

--- a/include/CSFML/Graphics/Font.h
+++ b/include/CSFML/Graphics/Font.h
@@ -84,7 +84,7 @@ CSFML_GRAPHICS_API sfFont* sfFont_copy(const sfFont* font);
 /// \param font Font to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfFont_destroy(sfFont* font);
+CSFML_GRAPHICS_API void sfFont_destroy(const sfFont* font);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get a glyph in a font

--- a/include/CSFML/Graphics/Image.h
+++ b/include/CSFML/Graphics/Image.h
@@ -140,7 +140,7 @@ CSFML_GRAPHICS_API sfImage* sfImage_copy(const sfImage* image);
 /// \param image Image to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfImage_destroy(sfImage* image);
+CSFML_GRAPHICS_API void sfImage_destroy(const sfImage* image);
 
 ////////////////////////////////////////////////////////////
 /// \brief Save an image to a file on disk

--- a/include/CSFML/Graphics/RectangleShape.h
+++ b/include/CSFML/Graphics/RectangleShape.h
@@ -62,7 +62,7 @@ CSFML_GRAPHICS_API sfRectangleShape* sfRectangleShape_copy(const sfRectangleShap
 /// \param shape Shape to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfRectangleShape_destroy(sfRectangleShape* shape);
+CSFML_GRAPHICS_API void sfRectangleShape_destroy(const sfRectangleShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a rectangle shape

--- a/include/CSFML/Graphics/RenderTexture.h
+++ b/include/CSFML/Graphics/RenderTexture.h
@@ -58,7 +58,7 @@ CSFML_GRAPHICS_API sfRenderTexture* sfRenderTexture_create(sfVector2u size, cons
 /// \param renderTexture Render texture to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfRenderTexture_destroy(sfRenderTexture* renderTexture);
+CSFML_GRAPHICS_API void sfRenderTexture_destroy(const sfRenderTexture* renderTexture);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the size of the rendering region of a render texture

--- a/include/CSFML/Graphics/RenderWindow.h
+++ b/include/CSFML/Graphics/RenderWindow.h
@@ -93,7 +93,7 @@ CSFML_GRAPHICS_API sfRenderWindow* sfRenderWindow_createFromHandle(sfWindowHandl
 /// \param renderWindow Render window to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfRenderWindow_destroy(sfRenderWindow* renderWindow);
+CSFML_GRAPHICS_API void sfRenderWindow_destroy(const sfRenderWindow* renderWindow);
 
 ////////////////////////////////////////////////////////////
 /// \brief Close a render window (but doesn't destroy the internal data)

--- a/include/CSFML/Graphics/Shader.h
+++ b/include/CSFML/Graphics/Shader.h
@@ -112,7 +112,7 @@ CSFML_GRAPHICS_API sfShader* sfShader_createFromStream(sfInputStream* vertexShad
 /// \param shader Shader to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfShader_destroy(sfShader* shader);
+CSFML_GRAPHICS_API void sfShader_destroy(const sfShader* shader);
 
 ////////////////////////////////////////////////////////////
 /// \brief Specify value for \p float uniform

--- a/include/CSFML/Graphics/Shape.h
+++ b/include/CSFML/Graphics/Shape.h
@@ -61,7 +61,7 @@ CSFML_GRAPHICS_API sfShape* sfShape_create(sfShapeGetPointCountCallback getPoint
 /// \param shape Shape to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfShape_destroy(sfShape* shape);
+CSFML_GRAPHICS_API void sfShape_destroy(const sfShape* shape);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a shape

--- a/include/CSFML/Graphics/Sprite.h
+++ b/include/CSFML/Graphics/Sprite.h
@@ -63,7 +63,7 @@ CSFML_GRAPHICS_API sfSprite* sfSprite_copy(const sfSprite* sprite);
 /// \param sprite Sprite to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfSprite_destroy(sfSprite* sprite);
+CSFML_GRAPHICS_API void sfSprite_destroy(const sfSprite* sprite);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a sprite

--- a/include/CSFML/Graphics/Text.h
+++ b/include/CSFML/Graphics/Text.h
@@ -77,7 +77,7 @@ CSFML_GRAPHICS_API sfText* sfText_copy(const sfText* text);
 /// \param text Text to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfText_destroy(sfText* text);
+CSFML_GRAPHICS_API void sfText_destroy(const sfText* text);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a text

--- a/include/CSFML/Graphics/Texture.h
+++ b/include/CSFML/Graphics/Texture.h
@@ -175,7 +175,7 @@ CSFML_GRAPHICS_API sfTexture* sfTexture_copy(const sfTexture* texture);
 /// \param texture Texture to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfTexture_destroy(sfTexture* texture);
+CSFML_GRAPHICS_API void sfTexture_destroy(const sfTexture* texture);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the size of the texture

--- a/include/CSFML/Graphics/Transformable.h
+++ b/include/CSFML/Graphics/Transformable.h
@@ -58,7 +58,7 @@ CSFML_GRAPHICS_API sfTransformable* sfTransformable_copy(const sfTransformable* 
 /// \param transformable Transformable to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfTransformable_destroy(sfTransformable* transformable);
+CSFML_GRAPHICS_API void sfTransformable_destroy(const sfTransformable* transformable);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of a transformable

--- a/include/CSFML/Graphics/VertexArray.h
+++ b/include/CSFML/Graphics/VertexArray.h
@@ -61,7 +61,7 @@ CSFML_GRAPHICS_API sfVertexArray* sfVertexArray_copy(const sfVertexArray* vertex
 /// \param vertexArray Vertex array to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfVertexArray_destroy(sfVertexArray* vertexArray);
+CSFML_GRAPHICS_API void sfVertexArray_destroy(const sfVertexArray* vertexArray);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the vertex count of a vertex array

--- a/include/CSFML/Graphics/VertexBuffer.h
+++ b/include/CSFML/Graphics/VertexBuffer.h
@@ -87,7 +87,7 @@ CSFML_GRAPHICS_API sfVertexBuffer* sfVertexBuffer_copy(const sfVertexBuffer* ver
 /// \param vertexBuffer Vertex buffer to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfVertexBuffer_destroy(sfVertexBuffer* vertexBuffer);
+CSFML_GRAPHICS_API void sfVertexBuffer_destroy(const sfVertexBuffer* vertexBuffer);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the vertex count

--- a/include/CSFML/Graphics/View.h
+++ b/include/CSFML/Graphics/View.h
@@ -70,7 +70,7 @@ CSFML_GRAPHICS_API sfView* sfView_copy(const sfView* view);
 /// \param view View to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfView_destroy(sfView* view);
+CSFML_GRAPHICS_API void sfView_destroy(const sfView* view);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the center of a view

--- a/include/CSFML/Network/Ftp.h
+++ b/include/CSFML/Network/Ftp.h
@@ -120,7 +120,7 @@ typedef enum
 /// \param ftpListingResponse Ftp listing response to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfFtpListingResponse_destroy(sfFtpListingResponse* ftpListingResponse);
+CSFML_NETWORK_API void sfFtpListingResponse_destroy(const sfFtpListingResponse* ftpListingResponse);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a FTP listing response status code means a success
@@ -182,7 +182,7 @@ CSFML_NETWORK_API const char* sfFtpListingResponse_getName(const sfFtpListingRes
 /// \param ftpDirectoryResponse Ftp directory response to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfFtpDirectoryResponse_destroy(sfFtpDirectoryResponse* ftpDirectoryResponse);
+CSFML_NETWORK_API void sfFtpDirectoryResponse_destroy(const sfFtpDirectoryResponse* ftpDirectoryResponse);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a FTP directory response status code means a success
@@ -251,7 +251,7 @@ CSFML_NETWORK_API const sfChar32* sfFtpDirectoryResponse_getDirectoryUnicode(con
 /// \param ftpResponse Ftp response to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfFtpResponse_destroy(sfFtpResponse* ftpResponse);
+CSFML_NETWORK_API void sfFtpResponse_destroy(const sfFtpResponse* ftpResponse);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a FTP response status code means a success
@@ -300,7 +300,7 @@ CSFML_NETWORK_API sfFtp* sfFtp_create(void);
 /// \param ftp Ftp object to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfFtp_destroy(sfFtp* ftp);
+CSFML_NETWORK_API void sfFtp_destroy(const sfFtp* ftp);
 
 ////////////////////////////////////////////////////////////
 /// \brief Connect to the specified FTP server

--- a/include/CSFML/Network/Http.h
+++ b/include/CSFML/Network/Http.h
@@ -102,7 +102,7 @@ CSFML_NETWORK_API sfHttpRequest* sfHttpRequest_create(void);
 /// \param httpRequest HTTP request to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfHttpRequest_destroy(sfHttpRequest* httpRequest);
+CSFML_NETWORK_API void sfHttpRequest_destroy(const sfHttpRequest* httpRequest);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the value of a header field of a HTTP request
@@ -177,7 +177,7 @@ CSFML_NETWORK_API void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const c
 /// \param httpResponse HTTP response to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfHttpResponse_destroy(sfHttpResponse* httpResponse);
+CSFML_NETWORK_API void sfHttpResponse_destroy(const sfHttpResponse* httpResponse);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the value of a field of a HTTP response
@@ -259,7 +259,7 @@ CSFML_NETWORK_API sfHttp* sfHttp_create(void);
 /// \param http Http object to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfHttp_destroy(sfHttp* http);
+CSFML_NETWORK_API void sfHttp_destroy(const sfHttp* http);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the target host of a HTTP object

--- a/include/CSFML/Network/Packet.h
+++ b/include/CSFML/Network/Packet.h
@@ -58,7 +58,7 @@ CSFML_NETWORK_API sfPacket* sfPacket_copy(const sfPacket* packet);
 /// \param packet Packet to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfPacket_destroy(sfPacket* packet);
+CSFML_NETWORK_API void sfPacket_destroy(const sfPacket* packet);
 
 ////////////////////////////////////////////////////////////
 /// \brief Append data to the end of a packet

--- a/include/CSFML/Network/SocketSelector.h
+++ b/include/CSFML/Network/SocketSelector.h
@@ -57,7 +57,7 @@ CSFML_NETWORK_API sfSocketSelector* sfSocketSelector_copy(const sfSocketSelector
 /// \param selector Socket selector to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfSocketSelector_destroy(sfSocketSelector* selector);
+CSFML_NETWORK_API void sfSocketSelector_destroy(const sfSocketSelector* selector);
 
 ////////////////////////////////////////////////////////////
 /// \brief Add a new socket to a socket selector

--- a/include/CSFML/Network/TcpListener.h
+++ b/include/CSFML/Network/TcpListener.h
@@ -48,7 +48,7 @@ CSFML_NETWORK_API sfTcpListener* sfTcpListener_create(void);
 /// \param listener TCP listener to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfTcpListener_destroy(sfTcpListener* listener);
+CSFML_NETWORK_API void sfTcpListener_destroy(const sfTcpListener* listener);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the blocking state of a TCP listener

--- a/include/CSFML/Network/TcpSocket.h
+++ b/include/CSFML/Network/TcpSocket.h
@@ -51,7 +51,7 @@ CSFML_NETWORK_API sfTcpSocket* sfTcpSocket_create(void);
 /// \param socket TCP socket to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfTcpSocket_destroy(sfTcpSocket* socket);
+CSFML_NETWORK_API void sfTcpSocket_destroy(const sfTcpSocket* socket);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the blocking state of a TCP listener

--- a/include/CSFML/Network/UdpSocket.h
+++ b/include/CSFML/Network/UdpSocket.h
@@ -50,7 +50,7 @@ CSFML_NETWORK_API sfUdpSocket* sfUdpSocket_create(void);
 /// \param socket UDP socket to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_NETWORK_API void sfUdpSocket_destroy(sfUdpSocket* socket);
+CSFML_NETWORK_API void sfUdpSocket_destroy(const sfUdpSocket* socket);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the blocking state of a UDP listener

--- a/include/CSFML/System/Buffer.h
+++ b/include/CSFML/System/Buffer.h
@@ -48,7 +48,7 @@ CSFML_SYSTEM_API sfBuffer* sfBuffer_create(void);
 /// \param buffer Buffer to delete
 ///
 ////////////////////////////////////////////////////////////
-CSFML_SYSTEM_API void sfBuffer_destroy(sfBuffer* buffer);
+CSFML_SYSTEM_API void sfBuffer_destroy(const sfBuffer* buffer);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the size of a buffer

--- a/include/CSFML/System/Clock.h
+++ b/include/CSFML/System/Clock.h
@@ -57,7 +57,7 @@ CSFML_SYSTEM_API sfClock* sfClock_copy(const sfClock* clock);
 /// \param clock Clock to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_SYSTEM_API void sfClock_destroy(sfClock* clock);
+CSFML_SYSTEM_API void sfClock_destroy(const sfClock* clock);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the time elapsed in a clock

--- a/include/CSFML/Window/Context.h
+++ b/include/CSFML/Window/Context.h
@@ -50,7 +50,7 @@ CSFML_WINDOW_API sfContext* sfContext_create(void);
 /// \param context Context to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_WINDOW_API void sfContext_destroy(sfContext* context);
+CSFML_WINDOW_API void sfContext_destroy(const sfContext* context);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check whether a given OpenGL extension is available.

--- a/include/CSFML/Window/Cursor.h
+++ b/include/CSFML/Window/Cursor.h
@@ -141,4 +141,4 @@ CSFML_WINDOW_API sfCursor* sfCursor_createFromSystem(sfCursorType type);
 /// \param cursor Cursor to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_WINDOW_API void sfCursor_destroy(sfCursor* cursor);
+CSFML_WINDOW_API void sfCursor_destroy(const sfCursor* cursor);

--- a/include/CSFML/Window/Window.h
+++ b/include/CSFML/Window/Window.h
@@ -146,7 +146,7 @@ CSFML_WINDOW_API sfWindow* sfWindow_createFromHandle(sfWindowHandle handle, cons
 /// \param window Window to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_WINDOW_API void sfWindow_destroy(sfWindow* window);
+CSFML_WINDOW_API void sfWindow_destroy(const sfWindow* window);
 
 ////////////////////////////////////////////////////////////
 /// \brief Close a window and destroy all the attached resources

--- a/include/CSFML/Window/WindowBase.h
+++ b/include/CSFML/Window/WindowBase.h
@@ -117,7 +117,7 @@ CSFML_WINDOW_API sfWindowBase* sfWindowBase_createFromHandle(sfWindowHandle hand
 /// \param windowBase Window to destroy
 ///
 ////////////////////////////////////////////////////////////
-CSFML_WINDOW_API void sfWindowBase_destroy(sfWindowBase* windowBase);
+CSFML_WINDOW_API void sfWindowBase_destroy(const sfWindowBase* windowBase);
 
 ////////////////////////////////////////////////////////////
 /// \brief Close a window and destroy all the attached resources

--- a/src/CSFML/Audio/Music.cpp
+++ b/src/CSFML/Audio/Music.cpp
@@ -76,7 +76,7 @@ sfMusic* sfMusic_createFromStream(sfInputStream* stream)
 
 
 ////////////////////////////////////////////////////////////
-void sfMusic_destroy(sfMusic* music)
+void sfMusic_destroy(const sfMusic* music)
 {
     delete music;
 }

--- a/src/CSFML/Audio/Sound.cpp
+++ b/src/CSFML/Audio/Sound.cpp
@@ -47,7 +47,7 @@ sfSound* sfSound_copy(const sfSound* sound)
 
 
 ////////////////////////////////////////////////////////////
-void sfSound_destroy(sfSound* sound)
+void sfSound_destroy(const sfSound* sound)
 {
     delete sound;
 }

--- a/src/CSFML/Audio/SoundBuffer.cpp
+++ b/src/CSFML/Audio/SoundBuffer.cpp
@@ -96,7 +96,7 @@ sfSoundBuffer* sfSoundBuffer_copy(const sfSoundBuffer* soundBuffer)
 
 
 ////////////////////////////////////////////////////////////
-void sfSoundBuffer_destroy(sfSoundBuffer* soundBuffer)
+void sfSoundBuffer_destroy(const sfSoundBuffer* soundBuffer)
 {
     delete soundBuffer;
 }

--- a/src/CSFML/Audio/SoundBufferRecorder.cpp
+++ b/src/CSFML/Audio/SoundBufferRecorder.cpp
@@ -37,7 +37,7 @@ sfSoundBufferRecorder* sfSoundBufferRecorder_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfSoundBufferRecorder_destroy(sfSoundBufferRecorder* soundBufferRecorder)
+void sfSoundBufferRecorder_destroy(const sfSoundBufferRecorder* soundBufferRecorder)
 {
     delete soundBufferRecorder;
 }

--- a/src/CSFML/Audio/SoundRecorder.cpp
+++ b/src/CSFML/Audio/SoundRecorder.cpp
@@ -42,7 +42,7 @@ sfSoundRecorder* sfSoundRecorder_create(sfSoundRecorderStartCallback   onStart,
 
 
 ////////////////////////////////////////////////////////////
-void sfSoundRecorder_destroy(sfSoundRecorder* soundRecorder)
+void sfSoundRecorder_destroy(const sfSoundRecorder* soundRecorder)
 {
     delete soundRecorder;
 }

--- a/src/CSFML/Audio/SoundStream.cpp
+++ b/src/CSFML/Audio/SoundStream.cpp
@@ -45,7 +45,7 @@ sfSoundStream* sfSoundStream_create(
 
 
 ////////////////////////////////////////////////////////////
-void sfSoundStream_destroy(sfSoundStream* soundStream)
+void sfSoundStream_destroy(const sfSoundStream* soundStream)
 {
     delete soundStream;
 }

--- a/src/CSFML/Graphics/CircleShape.cpp
+++ b/src/CSFML/Graphics/CircleShape.cpp
@@ -54,7 +54,7 @@ sfCircleShape* sfCircleShape_copy(const sfCircleShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-void sfCircleShape_destroy(sfCircleShape* shape)
+void sfCircleShape_destroy(const sfCircleShape* shape)
 {
     delete shape;
 }

--- a/src/CSFML/Graphics/ConvexShape.cpp
+++ b/src/CSFML/Graphics/ConvexShape.cpp
@@ -51,7 +51,7 @@ sfConvexShape* sfConvexShape_copy(const sfConvexShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-void sfConvexShape_destroy(sfConvexShape* shape)
+void sfConvexShape_destroy(const sfConvexShape* shape)
 {
     delete shape;
 }

--- a/src/CSFML/Graphics/Font.cpp
+++ b/src/CSFML/Graphics/Font.cpp
@@ -79,7 +79,7 @@ sfFont* sfFont_copy(const sfFont* font)
 
 
 ////////////////////////////////////////////////////////////
-void sfFont_destroy(sfFont* font)
+void sfFont_destroy(const sfFont* font)
 {
     delete font;
 }

--- a/src/CSFML/Graphics/Image.cpp
+++ b/src/CSFML/Graphics/Image.cpp
@@ -100,7 +100,7 @@ sfImage* sfImage_copy(const sfImage* image)
 
 
 ////////////////////////////////////////////////////////////
-void sfImage_destroy(sfImage* image)
+void sfImage_destroy(const sfImage* image)
 {
     delete image;
 }

--- a/src/CSFML/Graphics/RectangleShape.cpp
+++ b/src/CSFML/Graphics/RectangleShape.cpp
@@ -51,7 +51,7 @@ sfRectangleShape* sfRectangleShape_copy(const sfRectangleShape* shape)
 
 
 ////////////////////////////////////////////////////////////
-void sfRectangleShape_destroy(sfRectangleShape* shape)
+void sfRectangleShape_destroy(const sfRectangleShape* shape)
 {
     delete shape;
 }

--- a/src/CSFML/Graphics/RenderTexture.cpp
+++ b/src/CSFML/Graphics/RenderTexture.cpp
@@ -62,7 +62,7 @@ sfRenderTexture* sfRenderTexture_create(sfVector2u size, const sfContextSettings
 
 
 ////////////////////////////////////////////////////////////
-void sfRenderTexture_destroy(sfRenderTexture* renderTexture)
+void sfRenderTexture_destroy(const sfRenderTexture* renderTexture)
 {
     delete renderTexture->Target;
     delete renderTexture;

--- a/src/CSFML/Graphics/RenderWindow.cpp
+++ b/src/CSFML/Graphics/RenderWindow.cpp
@@ -109,7 +109,7 @@ sfRenderWindow* sfRenderWindow_createFromHandle(sfWindowHandle handle, const sfC
 
 
 ////////////////////////////////////////////////////////////
-void sfRenderWindow_destroy(sfRenderWindow* renderWindow)
+void sfRenderWindow_destroy(const sfRenderWindow* renderWindow)
 {
     delete renderWindow;
 }

--- a/src/CSFML/Graphics/Shader.cpp
+++ b/src/CSFML/Graphics/Shader.cpp
@@ -185,7 +185,7 @@ sfShader* sfShader_createFromStream(sfInputStream* vertexShaderStream,
 
 
 ////////////////////////////////////////////////////////////
-void sfShader_destroy(sfShader* shader)
+void sfShader_destroy(const sfShader* shader)
 {
     delete shader;
 }

--- a/src/CSFML/Graphics/Shape.cpp
+++ b/src/CSFML/Graphics/Shape.cpp
@@ -43,7 +43,7 @@ sfShape* sfShape_create(sfShapeGetPointCountCallback getPointCount, sfShapeGetPo
 
 
 ////////////////////////////////////////////////////////////
-void sfShape_destroy(sfShape* shape)
+void sfShape_destroy(const sfShape* shape)
 {
     delete shape;
 }

--- a/src/CSFML/Graphics/Sprite.cpp
+++ b/src/CSFML/Graphics/Sprite.cpp
@@ -54,7 +54,7 @@ sfSprite* sfSprite_copy(const sfSprite* sprite)
 
 
 ////////////////////////////////////////////////////////////
-void sfSprite_destroy(sfSprite* sprite)
+void sfSprite_destroy(const sfSprite* sprite)
 {
     delete sprite;
 }

--- a/src/CSFML/Graphics/Text.cpp
+++ b/src/CSFML/Graphics/Text.cpp
@@ -53,7 +53,7 @@ sfText* sfText_copy(const sfText* text)
 
 
 ////////////////////////////////////////////////////////////
-void sfText_destroy(sfText* text)
+void sfText_destroy(const sfText* text)
 {
     delete text;
 }

--- a/src/CSFML/Graphics/Texture.cpp
+++ b/src/CSFML/Graphics/Texture.cpp
@@ -199,7 +199,7 @@ sfTexture* sfTexture_copy(const sfTexture* texture)
 
 
 ////////////////////////////////////////////////////////////
-void sfTexture_destroy(sfTexture* texture)
+void sfTexture_destroy(const sfTexture* texture)
 {
     delete texture;
 }

--- a/src/CSFML/Graphics/Transformable.cpp
+++ b/src/CSFML/Graphics/Transformable.cpp
@@ -49,7 +49,7 @@ sfTransformable* sfTransformable_copy(const sfTransformable* transformable)
 
 
 ////////////////////////////////////////////////////////////
-void sfTransformable_destroy(sfTransformable* transformable)
+void sfTransformable_destroy(const sfTransformable* transformable)
 {
     delete transformable;
 }

--- a/src/CSFML/Graphics/VertexArray.cpp
+++ b/src/CSFML/Graphics/VertexArray.cpp
@@ -46,7 +46,7 @@ sfVertexArray* sfVertexArray_copy(const sfVertexArray* vertexArray)
 
 
 ////////////////////////////////////////////////////////////
-void sfVertexArray_destroy(sfVertexArray* vertexArray)
+void sfVertexArray_destroy(const sfVertexArray* vertexArray)
 {
     delete vertexArray;
 }

--- a/src/CSFML/Graphics/VertexBuffer.cpp
+++ b/src/CSFML/Graphics/VertexBuffer.cpp
@@ -59,7 +59,7 @@ sfVertexBuffer* sfVertexBuffer_copy(const sfVertexBuffer* vertexBuffer)
 
 
 ////////////////////////////////////////////////////////////
-void sfVertexBuffer_destroy(sfVertexBuffer* vertexBuffer)
+void sfVertexBuffer_destroy(const sfVertexBuffer* vertexBuffer)
 {
     delete vertexBuffer;
 }

--- a/src/CSFML/Graphics/View.cpp
+++ b/src/CSFML/Graphics/View.cpp
@@ -54,7 +54,7 @@ sfView* sfView_copy(const sfView* view)
 
 
 ////////////////////////////////////////////////////////////
-void sfView_destroy(sfView* view)
+void sfView_destroy(const sfView* view)
 {
     delete view;
 }

--- a/src/CSFML/Network/Ftp.cpp
+++ b/src/CSFML/Network/Ftp.cpp
@@ -60,7 +60,7 @@ static_assert(alignof(sfChar32) == alignof(char32_t));
 
 
 ////////////////////////////////////////////////////////////
-void sfFtpListingResponse_destroy(sfFtpListingResponse* ftpListingResponse)
+void sfFtpListingResponse_destroy(const sfFtpListingResponse* ftpListingResponse)
 {
     delete ftpListingResponse;
 }
@@ -107,7 +107,7 @@ const char* sfFtpListingResponse_getName(const sfFtpListingResponse* ftpListingR
 
 
 ////////////////////////////////////////////////////////////
-void sfFtpDirectoryResponse_destroy(sfFtpDirectoryResponse* ftpDirectoryResponse)
+void sfFtpDirectoryResponse_destroy(const sfFtpDirectoryResponse* ftpDirectoryResponse)
 {
     delete ftpDirectoryResponse;
 }
@@ -154,7 +154,7 @@ const sfChar32* sfFtpDirectoryResponse_getDirectoryUnicode(const sfFtpDirectoryR
 
 
 ////////////////////////////////////////////////////////////
-void sfFtpResponse_destroy(sfFtpResponse* ftpResponse)
+void sfFtpResponse_destroy(const sfFtpResponse* ftpResponse)
 {
     delete ftpResponse;
 }
@@ -192,7 +192,7 @@ sfFtp* sfFtp_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfFtp_destroy(sfFtp* ftp)
+void sfFtp_destroy(const sfFtp* ftp)
 {
     delete ftp;
 }

--- a/src/CSFML/Network/Http.cpp
+++ b/src/CSFML/Network/Http.cpp
@@ -37,7 +37,7 @@ sfHttpRequest* sfHttpRequest_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfHttpRequest_destroy(sfHttpRequest* httpRequest)
+void sfHttpRequest_destroy(const sfHttpRequest* httpRequest)
 {
     delete httpRequest;
 }
@@ -85,7 +85,7 @@ void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body)
 
 
 ////////////////////////////////////////////////////////////
-void sfHttpResponse_destroy(sfHttpResponse* httpResponse)
+void sfHttpResponse_destroy(const sfHttpResponse* httpResponse)
 {
     delete httpResponse;
 }
@@ -142,7 +142,7 @@ sfHttp* sfHttp_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfHttp_destroy(sfHttp* http)
+void sfHttp_destroy(const sfHttp* http)
 {
     delete http;
 }

--- a/src/CSFML/Network/Packet.cpp
+++ b/src/CSFML/Network/Packet.cpp
@@ -47,7 +47,7 @@ sfPacket* sfPacket_copy(const sfPacket* packet)
 
 
 ////////////////////////////////////////////////////////////
-void sfPacket_destroy(sfPacket* packet)
+void sfPacket_destroy(const sfPacket* packet)
 {
     delete packet;
 }

--- a/src/CSFML/Network/SocketSelector.cpp
+++ b/src/CSFML/Network/SocketSelector.cpp
@@ -48,7 +48,7 @@ sfSocketSelector* sfSocketSelector_copy(const sfSocketSelector* selector)
 
 
 ////////////////////////////////////////////////////////////
-void sfSocketSelector_destroy(sfSocketSelector* selector)
+void sfSocketSelector_destroy(const sfSocketSelector* selector)
 {
     delete selector;
 }

--- a/src/CSFML/Network/TcpListener.cpp
+++ b/src/CSFML/Network/TcpListener.cpp
@@ -38,7 +38,7 @@ sfTcpListener* sfTcpListener_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfTcpListener_destroy(sfTcpListener* listener)
+void sfTcpListener_destroy(const sfTcpListener* listener)
 {
     delete listener;
 }

--- a/src/CSFML/Network/TcpSocket.cpp
+++ b/src/CSFML/Network/TcpSocket.cpp
@@ -42,7 +42,7 @@ sfTcpSocket* sfTcpSocket_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfTcpSocket_destroy(sfTcpSocket* socket)
+void sfTcpSocket_destroy(const sfTcpSocket* socket)
 {
     delete socket;
 }

--- a/src/CSFML/Network/UdpSocket.cpp
+++ b/src/CSFML/Network/UdpSocket.cpp
@@ -42,7 +42,7 @@ sfUdpSocket* sfUdpSocket_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfUdpSocket_destroy(sfUdpSocket* socket)
+void sfUdpSocket_destroy(const sfUdpSocket* socket)
 {
     delete socket;
 }

--- a/src/CSFML/System/Buffer.cpp
+++ b/src/CSFML/System/Buffer.cpp
@@ -39,7 +39,7 @@ sfBuffer* sfBuffer_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfBuffer_destroy(sfBuffer* buffer)
+void sfBuffer_destroy(const sfBuffer* buffer)
 {
     delete buffer;
 }

--- a/src/CSFML/System/Clock.cpp
+++ b/src/CSFML/System/Clock.cpp
@@ -47,7 +47,7 @@ sfClock* sfClock_copy(const sfClock* clock)
 
 
 ////////////////////////////////////////////////////////////
-void sfClock_destroy(sfClock* clock)
+void sfClock_destroy(const sfClock* clock)
 {
     delete clock;
 }

--- a/src/CSFML/Window/Context.cpp
+++ b/src/CSFML/Window/Context.cpp
@@ -38,7 +38,7 @@ sfContext* sfContext_create()
 
 
 ////////////////////////////////////////////////////////////
-void sfContext_destroy(sfContext* context)
+void sfContext_destroy(const sfContext* context)
 {
     delete context;
 }

--- a/src/CSFML/Window/Cursor.cpp
+++ b/src/CSFML/Window/Cursor.cpp
@@ -53,7 +53,7 @@ sfCursor* sfCursor_createFromSystem(sfCursorType type)
 
 
 ////////////////////////////////////////////////////////////
-void sfCursor_destroy(sfCursor* cursor)
+void sfCursor_destroy(const sfCursor* cursor)
 {
     delete cursor;
 }

--- a/src/CSFML/Window/Window.cpp
+++ b/src/CSFML/Window/Window.cpp
@@ -84,7 +84,7 @@ sfWindow* sfWindow_createFromHandle(sfWindowHandle handle, const sfContextSettin
 
 
 ////////////////////////////////////////////////////////////
-void sfWindow_destroy(sfWindow* window)
+void sfWindow_destroy(const sfWindow* window)
 {
     delete window;
 }

--- a/src/CSFML/Window/WindowBase.cpp
+++ b/src/CSFML/Window/WindowBase.cpp
@@ -70,7 +70,7 @@ sfWindowBase* sfWindowBase_createFromHandle(sfWindowHandle handle)
 
 
 ////////////////////////////////////////////////////////////
-void sfWindowBase_destroy(sfWindowBase* windowBase)
+void sfWindowBase_destroy(const sfWindowBase* windowBase)
 {
     delete windowBase;
 }


### PR DESCRIPTION
It's perfectly valid to call `delete` on a pointer-to-const. However, all CSFML `_destroy` functions use a pointer-to-non-const. One downside of this approach is that you cannot create an object and bind it to a `const T*`. Doing so will make it impossible to call that object's `_delete` function.