### PR TITLE
Assert string arguments are not null

### DIFF
--- a/src/CSFML/Audio/SoundBufferRecorder.cpp
+++ b/src/CSFML/Audio/SoundBufferRecorder.cpp
@@ -81,6 +81,7 @@ const sfSoundBuffer* sfSoundBufferRecorder_getBuffer(const sfSoundBufferRecorder
 bool sfSoundBufferRecorder_setDevice(sfSoundBufferRecorder* soundBufferRecorder, const char* name)
 {
     assert(soundBufferRecorder);
+    assert(name);
     return soundBufferRecorder->This.setDevice(name);
 }
 

--- a/src/CSFML/Audio/SoundRecorder.cpp
+++ b/src/CSFML/Audio/SoundRecorder.cpp
@@ -113,6 +113,7 @@ const char* sfSoundRecorder_getDefaultDevice()
 bool sfSoundRecorder_setDevice(sfSoundRecorder* soundRecorder, const char* name)
 {
     assert(soundRecorder);
+    assert(name);
     return soundRecorder->This.setDevice(name);
 }
 

--- a/src/CSFML/Graphics/Image.cpp
+++ b/src/CSFML/Graphics/Image.cpp
@@ -122,6 +122,7 @@ bool sfImage_saveToMemory(const sfImage* image, sfBuffer* output, const char* fo
 {
     assert(image);
     assert(output);
+    assert(format);
 
     auto data = image->This.saveToMemory(format);
 


### PR DESCRIPTION
For these functions, providing a null pointer argument would result in invoking undefined behavior. As far as I know, these are the last functions in CSFML where nullptr args could potentially be converted into a `std::string` thus invoking UB. We have more `const char*` parameters but those values get checked for nullness before use so UB is not a concern in those cases.