### PR TITLE
possible null pointer dereference in sfRenderTexture_destroy

### DIFF
--- a/src/CSFML/Graphics/RenderTexture.cpp
+++ b/src/CSFML/Graphics/RenderTexture.cpp
@@ -53,18 +53,17 @@ sfRenderTexture* sfRenderTexture_create(sfVector2u size, const sfContextSettings
     if (!renderTexture.resize(convertVector2(size), params))
         return nullptr;
 
-    auto*      texture     = new sfTexture(const_cast<sf::Texture*>(&renderTexture.getTexture()));
+    auto       texture     = std::make_unique<sfTexture>(const_cast<sf::Texture*>(&renderTexture.getTexture()));
     const auto defaultView = sfView{renderTexture.getDefaultView()};
     const auto currentView = sfView{renderTexture.getView()};
 
-    return new sfRenderTexture{std::move(renderTexture), texture, defaultView, currentView};
+    return new sfRenderTexture{std::move(renderTexture), std::move(texture), defaultView, currentView};
 }
 
 
 ////////////////////////////////////////////////////////////
 void sfRenderTexture_destroy(const sfRenderTexture* renderTexture)
 {
-    delete renderTexture->Target;
     delete renderTexture;
 }
 
@@ -275,7 +274,7 @@ void sfRenderTexture_resetGLStates(sfRenderTexture* renderTexture)
 const sfTexture* sfRenderTexture_getTexture(const sfRenderTexture* renderTexture)
 {
     assert(renderTexture);
-    return renderTexture->Target;
+    return renderTexture->Target.get();
 }
 
 

--- a/src/CSFML/Graphics/RenderTextureStruct.hpp
+++ b/src/CSFML/Graphics/RenderTextureStruct.hpp
@@ -32,14 +32,16 @@
 
 #include <SFML/Graphics/RenderTexture.hpp>
 
+#include <memory>
+
 
 ////////////////////////////////////////////////////////////
 // Internal structure of sfRenderTexture
 ////////////////////////////////////////////////////////////
 struct sfRenderTexture
 {
-    sf::RenderTexture This;
-    const sfTexture*  Target;
-    sfView            DefaultView;
-    sfView            CurrentView;
+    sf::RenderTexture                This;
+    std::unique_ptr<const sfTexture> Target;
+    sfView                           DefaultView;
+    sfView                           CurrentView;
 };


### PR DESCRIPTION
```cpp
void sfRenderTexture_destroy(const sfRenderTexture* renderTexture)
{
    delete renderTexture->Target;
    delete renderTexture;
}
```

if renderTexture is null then we are dereferencing a null pointer, so I fixed it by making Target a `std::unique_ptr` instead of `if(renderTexture) delete renderTexture->Target` check and it better resembles the ownership model.