### PR TITLE
use aggregate initialization to initialize

### DIFF
--- a/src/CSFML/Graphics/Color.cpp
+++ b/src/CSFML/Graphics/Color.cpp
@@ -45,33 +45,26 @@ const sfColor sfTransparent = sfColor_fromRGBA(0, 0, 0, 0);
 ////////////////////////////////////////////////////////////
 sfColor sfColor_fromRGB(uint8_t red, uint8_t green, uint8_t blue)
 {
-    return sfColor_fromRGBA(red, green, blue, 255);
+    return {red, green, blue, 255};
 }
 
 
 ////////////////////////////////////////////////////////////
 sfColor sfColor_fromRGBA(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)
 {
-    sfColor color;
-
-    color.r = red;
-    color.g = green;
-    color.b = blue;
-    color.a = alpha;
-
-    return color;
+    return {red, green, blue, alpha};
 }
 
 
 ////////////////////////////////////////////////////////////
 sfColor sfColor_fromInteger(uint32_t color)
 {
-    auto red   = static_cast<uint8_t>((color & 0xff000000) >> 24);
-    auto green = static_cast<uint8_t>((color & 0x00ff0000) >> 16);
-    auto blue  = static_cast<uint8_t>((color & 0x0000ff00) >> 8);
-    auto alpha = static_cast<uint8_t>((color & 0x000000ff) >> 0);
-
-    return sfColor_fromRGBA(red, green, blue, alpha);
+    return {
+        static_cast<uint8_t>((color & 0xff000000) >> 24),
+        static_cast<uint8_t>((color & 0x00ff0000) >> 16),
+        static_cast<uint8_t>((color & 0x0000ff00) >> 8),
+        static_cast<uint8_t>((color & 0x000000ff) >> 0),
+    };
 }
 
 
@@ -85,43 +78,34 @@ uint32_t sfColor_toInteger(sfColor color)
 ////////////////////////////////////////////////////////////
 sfColor sfColor_add(sfColor color1, sfColor color2)
 {
-    int red   = std::min(color1.r + color2.r, 255);
-    int green = std::min(color1.g + color2.g, 255);
-    int blue  = std::min(color1.b + color2.b, 255);
-    int alpha = std::min(color1.a + color2.a, 255);
-
-    return sfColor_fromRGBA(static_cast<uint8_t>(red),
-                            static_cast<uint8_t>(green),
-                            static_cast<uint8_t>(blue),
-                            static_cast<uint8_t>(alpha));
+    return {
+        static_cast<uint8_t>(std::min(color1.r + color2.r, 255)),
+        static_cast<uint8_t>(std::min(color1.g + color2.g, 255)),
+        static_cast<uint8_t>(std::min(color1.b + color2.b, 255)),
+        static_cast<uint8_t>(std::min(color1.a + color2.a, 255)),
+    };
 }
 
 
 ////////////////////////////////////////////////////////////
 sfColor sfColor_subtract(sfColor color1, sfColor color2)
 {
-    int red   = std::max(color1.r - color2.r, 0);
-    int green = std::max(color1.g - color2.g, 0);
-    int blue  = std::max(color1.b - color2.b, 0);
-    int alpha = std::max(color1.a - color2.a, 0);
-
-    return sfColor_fromRGBA(static_cast<uint8_t>(red),
-                            static_cast<uint8_t>(green),
-                            static_cast<uint8_t>(blue),
-                            static_cast<uint8_t>(alpha));
+    return {
+        static_cast<uint8_t>(std::max(color1.r - color2.r, 0)),
+        static_cast<uint8_t>(std::max(color1.g - color2.g, 0)),
+        static_cast<uint8_t>(std::max(color1.b - color2.b, 0)),
+        static_cast<uint8_t>(std::max(color1.a - color2.a, 0)),
+    };
 }
 
 
 ////////////////////////////////////////////////////////////
 sfColor sfColor_modulate(sfColor color1, sfColor color2)
 {
-    int red   = color1.r * color2.r / 255;
-    int green = color1.g * color2.g / 255;
-    int blue  = color1.b * color2.b / 255;
-    int alpha = color1.a * color2.a / 255;
-
-    return sfColor_fromRGBA(static_cast<uint8_t>(red),
-                            static_cast<uint8_t>(green),
-                            static_cast<uint8_t>(blue),
-                            static_cast<uint8_t>(alpha));
+    return {
+        static_cast<uint8_t>(color1.r * color2.r / 255),
+        static_cast<uint8_t>(color1.g * color2.g / 255),
+        static_cast<uint8_t>(color1.b * color2.b / 255),
+        static_cast<uint8_t>(color1.a * color2.a / 255),
+    };
 }

--- a/src/CSFML/Graphics/Shader.cpp
+++ b/src/CSFML/Graphics/Shader.cpp
@@ -201,13 +201,14 @@ void sfShader_setVec4Uniform(sfShader* shader, const char* name, sfGlslVec4 vect
 ////////////////////////////////////////////////////////////
 void sfShader_setColorUniform(sfShader* shader, const char* name, sfColor color)
 {
-    sfGlslVec4 vec4;
-    vec4.x = color.r / 255.f;
-    vec4.y = color.g / 255.f;
-    vec4.z = color.b / 255.f;
-    vec4.w = color.a / 255.f;
-
-    sfShader_setVec4Uniform(shader, name, vec4);
+    sfShader_setVec4Uniform(shader,
+                            name,
+                            {
+                                color.r / 255.f,
+                                color.g / 255.f,
+                                color.b / 255.f,
+                                color.a / 255.f,
+                            });
 }
 
 ////////////////////////////////////////////////////////////
@@ -249,13 +250,14 @@ void sfShader_setIvec4Uniform(sfShader* shader, const char* name, sfGlslIvec4 ve
 ////////////////////////////////////////////////////////////
 void sfShader_setIntColorUniform(sfShader* shader, const char* name, sfColor color)
 {
-    sfGlslIvec4 ivec4;
-    ivec4.x = static_cast<int>(color.r);
-    ivec4.y = static_cast<int>(color.g);
-    ivec4.z = static_cast<int>(color.b);
-    ivec4.w = static_cast<int>(color.a);
-
-    sfShader_setIvec4Uniform(shader, name, ivec4);
+    sfShader_setIvec4Uniform(shader,
+                             name,
+                             {
+                                 static_cast<int>(color.r),
+                                 static_cast<int>(color.g),
+                                 static_cast<int>(color.b),
+                                 static_cast<int>(color.a),
+                             });
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/CSFML/Graphics/Transform.cpp
+++ b/src/CSFML/Graphics/Transform.cpp
@@ -48,8 +48,13 @@ const sfTransform sfTransform_Identity = {
 ////////////////////////////////////////////////////////////
 sfTransform sfTransform_fromMatrix(float a00, float a01, float a02, float a10, float a11, float a12, float a20, float a21, float a22)
 {
-    sfTransform transform = {a00, a01, a02, a10, a11, a12, a20, a21, a22};
-    return transform;
+    // clang-format off
+    return {
+        a00, a01, a02,
+        a10, a11, a12,
+        a20, a21, a22,
+    };
+    // clang-format on
 }
 
 

--- a/src/CSFML/Graphics/Transformable.cpp
+++ b/src/CSFML/Graphics/Transformable.cpp
@@ -34,9 +34,7 @@
 ////////////////////////////////////////////////////////////
 sfTransformable* sfTransformable_create()
 {
-    auto* transformable = new sfTransformable;
-
-    return transformable;
+    return new sfTransformable;
 }
 
 

--- a/src/CSFML/System/Time.cpp
+++ b/src/CSFML/System/Time.cpp
@@ -56,25 +56,19 @@ int64_t sfTime_asMicroseconds(sfTime time)
 ////////////////////////////////////////////////////////////
 sfTime sfSeconds(float amount)
 {
-    sfTime time;
-    time.microseconds = static_cast<int64_t>(amount * 1000000);
-    return time;
+    return {static_cast<int64_t>(amount * 1000000)};
 }
 
 
 ////////////////////////////////////////////////////////////
 sfTime sfMilliseconds(int32_t amount)
 {
-    sfTime time;
-    time.microseconds = static_cast<int64_t>(amount) * 1000;
-    return time;
+    return {static_cast<int64_t>(amount * 1000)};
 }
 
 
 ////////////////////////////////////////////////////////////
 sfTime sfMicroseconds(int64_t amount)
 {
-    sfTime time;
-    time.microseconds = amount;
-    return time;
+    return {amount};
 }


### PR DESCRIPTION
I personally think it is clearer than the variable + member assignments as the layout of sfColor is guranteed and known and this removes some intermediary variables.