### PR TITLE
remove cstyle default init

### DIFF
--- a/src/CSFML/Network/IpAddress.cpp
+++ b/src/CSFML/Network/IpAddress.cpp
@@ -37,7 +37,7 @@ namespace
 // Helper function for converting a SFML address to a CSFML one
 [[nodiscard]] sfIpAddress fromSFMLAddress(std::optional<sf::IpAddress> address)
 {
-    sfIpAddress result = {0};
+    sfIpAddress result{};
 
     if (address)
     {


### PR DESCRIPTION
in C the initializer list of structs cannot be empty (until C23) but in C++ they can be empty.