### PR TITLE
cast to larger type before doing arithmetic to avoid signed integer o…

### DIFF
--- a/src/CSFML/System/Time.cpp
+++ b/src/CSFML/System/Time.cpp
@@ -63,7 +63,7 @@ sfTime sfSeconds(float amount)
 ////////////////////////////////////////////////////////////
 sfTime sfMilliseconds(int32_t amount)
 {
-    return {static_cast<int64_t>(amount * 1000)};
+    return {int64_t{amount} * 1000};
 }
 
 

--- a/test/System/Time.test.cpp
+++ b/test/System/Time.test.cpp
@@ -28,4 +28,7 @@ TEST_CASE("[System] sfTime")
     CHECK(sfSeconds(10).microseconds == 10'000'000);
     CHECK(sfMilliseconds(10).microseconds == 10'000);
     CHECK(sfMicroseconds(10).microseconds == 10);
+
+    CHECK(sfMilliseconds(std::numeric_limits<int32_t>::max()).microseconds == 2'147'483'647'000);
+    CHECK(sfMicroseconds(std::numeric_limits<int64_t>::max()).microseconds == std::numeric_limits<int64_t>::max());
 }


### PR DESCRIPTION
…verflow

https://godbolt.org/z/soTad4zEq

this godbolt links shows that it is UB to multiply then cast if the amount is large enough