### PR TITLE
check malloc return value for NULL and update docs

### DIFF
--- a/include/CSFML/Network/Ftp.h
+++ b/include/CSFML/Network/Ftp.h
@@ -225,7 +225,7 @@ CSFML_NETWORK_API const char* sfFtpDirectoryResponse_getMessage(const sfFtpDirec
 ///
 /// \param ftpDirectoryResponse Ftp directory response
 ///
-/// \return Directory name
+/// \return Directory name or NULL if it failed
 ///
 ////////////////////////////////////////////////////////////
 CSFML_NETWORK_API const char* sfFtpDirectoryResponse_getDirectory(const sfFtpDirectoryResponse* ftpDirectoryResponse);
@@ -239,7 +239,7 @@ CSFML_NETWORK_API const char* sfFtpDirectoryResponse_getDirectory(const sfFtpDir
 ///
 /// \param ftpDirectoryResponse Ftp directory response
 ///
-/// \return Directory name
+/// \return Directory name or NULL if it failed
 ///
 ////////////////////////////////////////////////////////////
 CSFML_NETWORK_API const sfChar32* sfFtpDirectoryResponse_getDirectoryUnicode(const sfFtpDirectoryResponse* ftpDirectoryResponse);

--- a/src/CSFML/Network/Ftp.cpp
+++ b/src/CSFML/Network/Ftp.cpp
@@ -51,6 +51,8 @@ static_assert(alignof(sfChar32) == alignof(char32_t));
 {
     const std::size_t byteCount = sizeof(sfChar32) * str.getSize();
     auto*             utf32     = static_cast<sfChar32*>(std::malloc(byteCount + sizeof(sfChar32)));
+    if (!utf32)
+        return nullptr;
     std::memcpy(utf32, str.getData(), byteCount);
     utf32[str.getSize()] = 0;
 


### PR DESCRIPTION
`sfFtpDirectoryResponse_getDirectory` can fail and return NULL becuase 'strdup' returns null on failure and it didn't mention it in the docs but `sfFtpDirectoryResponse_getDirectoryUnicode` didn't and just had UB due not checking return value of malloc.

typing `NULL` instead of `nullptr` in the docs made me age 30 years btw