### PR TITLE
Pass by reference if it is never null

### DIFF
--- a/src/CSFML/Graphics/RenderWindow.cpp
+++ b/src/CSFML/Graphics/RenderWindow.cpp
@@ -145,7 +145,7 @@ bool sfRenderWindow_pollEvent(sfRenderWindow* renderWindow, sfEvent* event)
 {
     assert(renderWindow);
     assert(event);
-    return convertEvent(renderWindow->pollEvent(), event);
+    return convertEvent(renderWindow->pollEvent(), *event);
 }
 
 
@@ -154,7 +154,7 @@ bool sfRenderWindow_waitEvent(sfRenderWindow* renderWindow, sfTime timeout, sfEv
 {
     assert(renderWindow);
     assert(event);
-    return convertEvent(renderWindow->waitEvent(sf::microseconds(timeout.microseconds)), event);
+    return convertEvent(renderWindow->waitEvent(sf::microseconds(timeout.microseconds)), *event);
 }
 
 

--- a/src/CSFML/Window/ConvertEvent.hpp
+++ b/src/CSFML/Window/ConvertEvent.hpp
@@ -39,142 +39,142 @@
 ////////////////////////////////////////////////////////////
 // Convert sf::Event to sfEvent
 ////////////////////////////////////////////////////////////
-[[nodiscard]] inline bool convertEvent(const std::optional<sf::Event>& sfmlEvent, sfEvent* event)
+[[nodiscard]] inline bool convertEvent(const std::optional<sf::Event>& sfmlEvent, sfEvent& event)
 {
     if (!sfmlEvent)
         return false;
 
     if (sfmlEvent->is<sf::Event::Closed>())
     {
-        event->type = sfEvtClosed;
+        event.type = sfEvtClosed;
     }
     else if (const auto* resized = sfmlEvent->getIf<sf::Event::Resized>())
     {
-        event->type      = sfEvtResized;
-        event->size.size = convertVector2(resized->size);
+        event.type      = sfEvtResized;
+        event.size.size = convertVector2(resized->size);
     }
     else if (sfmlEvent->is<sf::Event::FocusLost>())
     {
-        event->type = sfEvtFocusLost;
+        event.type = sfEvtFocusLost;
     }
     else if (sfmlEvent->is<sf::Event::FocusGained>())
     {
-        event->type = sfEvtFocusGained;
+        event.type = sfEvtFocusGained;
     }
     else if (const auto* textEntered = sfmlEvent->getIf<sf::Event::TextEntered>())
     {
-        event->type         = sfEvtTextEntered;
-        event->text.unicode = textEntered->unicode;
+        event.type         = sfEvtTextEntered;
+        event.text.unicode = textEntered->unicode;
     }
     else if (const auto* keyReleased = sfmlEvent->getIf<sf::Event::KeyReleased>())
     {
-        event->type         = sfEvtKeyReleased;
-        event->key.code     = static_cast<sfKeyCode>(keyReleased->code);
-        event->key.scancode = static_cast<sfScancode>(keyReleased->scancode);
-        event->key.alt      = keyReleased->alt;
-        event->key.control  = keyReleased->control;
-        event->key.shift    = keyReleased->shift;
-        event->key.system   = keyReleased->system;
+        event.type         = sfEvtKeyReleased;
+        event.key.code     = static_cast<sfKeyCode>(keyReleased->code);
+        event.key.scancode = static_cast<sfScancode>(keyReleased->scancode);
+        event.key.alt      = keyReleased->alt;
+        event.key.control  = keyReleased->control;
+        event.key.shift    = keyReleased->shift;
+        event.key.system   = keyReleased->system;
     }
     else if (const auto* keyPressed = sfmlEvent->getIf<sf::Event::KeyPressed>())
     {
-        event->type         = sfEvtKeyPressed;
-        event->key.code     = static_cast<sfKeyCode>(keyPressed->code);
-        event->key.scancode = static_cast<sfScancode>(keyPressed->scancode);
-        event->key.alt      = keyPressed->alt;
-        event->key.control  = keyPressed->control;
-        event->key.shift    = keyPressed->shift;
-        event->key.system   = keyPressed->system;
+        event.type         = sfEvtKeyPressed;
+        event.key.code     = static_cast<sfKeyCode>(keyPressed->code);
+        event.key.scancode = static_cast<sfScancode>(keyPressed->scancode);
+        event.key.alt      = keyPressed->alt;
+        event.key.control  = keyPressed->control;
+        event.key.shift    = keyPressed->shift;
+        event.key.system   = keyPressed->system;
     }
     else if (const auto* mouseWheelScrolled = sfmlEvent->getIf<sf::Event::MouseWheelScrolled>())
     {
-        event->type                      = sfEvtMouseWheelScrolled;
-        event->mouseWheelScroll.wheel    = static_cast<sfMouseWheel>(mouseWheelScrolled->wheel);
-        event->mouseWheelScroll.delta    = mouseWheelScrolled->delta;
-        event->mouseWheelScroll.position = convertVector2(mouseWheelScrolled->position);
+        event.type                      = sfEvtMouseWheelScrolled;
+        event.mouseWheelScroll.wheel    = static_cast<sfMouseWheel>(mouseWheelScrolled->wheel);
+        event.mouseWheelScroll.delta    = mouseWheelScrolled->delta;
+        event.mouseWheelScroll.position = convertVector2(mouseWheelScrolled->position);
     }
     else if (const auto* mouseButtonPressed = sfmlEvent->getIf<sf::Event::MouseButtonPressed>())
     {
-        event->type                 = sfEvtMouseButtonPressed;
-        event->mouseButton.button   = static_cast<sfMouseButton>(mouseButtonPressed->button);
-        event->mouseButton.position = convertVector2(mouseButtonPressed->position);
+        event.type                 = sfEvtMouseButtonPressed;
+        event.mouseButton.button   = static_cast<sfMouseButton>(mouseButtonPressed->button);
+        event.mouseButton.position = convertVector2(mouseButtonPressed->position);
     }
     else if (const auto* mouseButtonReleased = sfmlEvent->getIf<sf::Event::MouseButtonReleased>())
     {
-        event->type                 = sfEvtMouseButtonReleased;
-        event->mouseButton.button   = static_cast<sfMouseButton>(mouseButtonReleased->button);
-        event->mouseButton.position = convertVector2(mouseButtonReleased->position);
+        event.type                 = sfEvtMouseButtonReleased;
+        event.mouseButton.button   = static_cast<sfMouseButton>(mouseButtonReleased->button);
+        event.mouseButton.position = convertVector2(mouseButtonReleased->position);
     }
     else if (const auto* mouseMoved = sfmlEvent->getIf<sf::Event::MouseMoved>())
     {
-        event->type               = sfEvtMouseMoved;
-        event->mouseMove.position = convertVector2(mouseMoved->position);
+        event.type               = sfEvtMouseMoved;
+        event.mouseMove.position = convertVector2(mouseMoved->position);
     }
     else if (const auto* mouseMovedRaw = sfmlEvent->getIf<sf::Event::MouseMovedRaw>())
     {
-        event->type               = sfEvtMouseMovedRaw;
-        event->mouseMoveRaw.delta = convertVector2(mouseMovedRaw->delta);
+        event.type               = sfEvtMouseMovedRaw;
+        event.mouseMoveRaw.delta = convertVector2(mouseMovedRaw->delta);
     }
     else if (sfmlEvent->is<sf::Event::MouseEntered>())
     {
-        event->type = sfEvtMouseEntered;
+        event.type = sfEvtMouseEntered;
     }
     else if (sfmlEvent->is<sf::Event::MouseLeft>())
     {
-        event->type = sfEvtMouseLeft;
+        event.type = sfEvtMouseLeft;
     }
     else if (const auto* joystickButtonPressed = sfmlEvent->getIf<sf::Event::JoystickButtonPressed>())
     {
-        event->type                      = sfEvtJoystickButtonPressed;
-        event->joystickButton.joystickId = joystickButtonPressed->joystickId;
-        event->joystickButton.button     = joystickButtonPressed->button;
+        event.type                      = sfEvtJoystickButtonPressed;
+        event.joystickButton.joystickId = joystickButtonPressed->joystickId;
+        event.joystickButton.button     = joystickButtonPressed->button;
     }
     else if (const auto* joystickButtonReleased = sfmlEvent->getIf<sf::Event::JoystickButtonReleased>())
     {
-        event->type                      = sfEvtJoystickButtonReleased;
-        event->joystickButton.joystickId = joystickButtonReleased->joystickId;
-        event->joystickButton.button     = joystickButtonReleased->button;
+        event.type                      = sfEvtJoystickButtonReleased;
+        event.joystickButton.joystickId = joystickButtonReleased->joystickId;
+        event.joystickButton.button     = joystickButtonReleased->button;
     }
     else if (const auto* joystickMoved = sfmlEvent->getIf<sf::Event::JoystickMoved>())
     {
-        event->type                    = sfEvtJoystickMoved;
-        event->joystickMove.joystickId = joystickMoved->joystickId;
-        event->joystickMove.axis       = static_cast<sfJoystickAxis>(joystickMoved->axis);
-        event->joystickMove.position   = joystickMoved->position;
+        event.type                    = sfEvtJoystickMoved;
+        event.joystickMove.joystickId = joystickMoved->joystickId;
+        event.joystickMove.axis       = static_cast<sfJoystickAxis>(joystickMoved->axis);
+        event.joystickMove.position   = joystickMoved->position;
     }
     else if (const auto* joystickConnected = sfmlEvent->getIf<sf::Event::JoystickConnected>())
     {
-        event->type                       = sfEvtJoystickConnected;
-        event->joystickConnect.joystickId = joystickConnected->joystickId;
+        event.type                       = sfEvtJoystickConnected;
+        event.joystickConnect.joystickId = joystickConnected->joystickId;
     }
     else if (const auto* joystickDisconnected = sfmlEvent->getIf<sf::Event::JoystickDisconnected>())
     {
-        event->type                       = sfEvtJoystickDisconnected;
-        event->joystickConnect.joystickId = joystickDisconnected->joystickId;
+        event.type                       = sfEvtJoystickDisconnected;
+        event.joystickConnect.joystickId = joystickDisconnected->joystickId;
     }
     else if (const auto* touchBegan = sfmlEvent->getIf<sf::Event::TouchBegan>())
     {
-        event->type           = sfEvtTouchBegan;
-        event->touch.finger   = touchBegan->finger;
-        event->touch.position = convertVector2(touchBegan->position);
+        event.type           = sfEvtTouchBegan;
+        event.touch.finger   = touchBegan->finger;
+        event.touch.position = convertVector2(touchBegan->position);
     }
     else if (const auto* touchMoved = sfmlEvent->getIf<sf::Event::TouchMoved>())
     {
-        event->type           = sfEvtTouchMoved;
-        event->touch.finger   = touchMoved->finger;
-        event->touch.position = convertVector2(touchMoved->position);
+        event.type           = sfEvtTouchMoved;
+        event.touch.finger   = touchMoved->finger;
+        event.touch.position = convertVector2(touchMoved->position);
     }
     else if (const auto* touchEnded = sfmlEvent->getIf<sf::Event::TouchEnded>())
     {
-        event->type           = sfEvtTouchEnded;
-        event->touch.finger   = touchEnded->finger;
-        event->touch.position = convertVector2(touchEnded->position);
+        event.type           = sfEvtTouchEnded;
+        event.touch.finger   = touchEnded->finger;
+        event.touch.position = convertVector2(touchEnded->position);
     }
     else if (const auto* sensorChanged = sfmlEvent->getIf<sf::Event::SensorChanged>())
     {
-        event->type              = sfEvtSensorChanged;
-        event->sensor.sensorType = static_cast<sfSensorType>(sensorChanged->type);
-        event->sensor.value      = convertVector3(sensorChanged->value);
+        event.type              = sfEvtSensorChanged;
+        event.sensor.sensorType = static_cast<sfSensorType>(sensorChanged->type);
+        event.sensor.value      = convertVector3(sensorChanged->value);
     }
 
     return true;

--- a/src/CSFML/Window/Window.cpp
+++ b/src/CSFML/Window/Window.cpp
@@ -114,7 +114,7 @@ bool sfWindow_pollEvent(sfWindow* window, sfEvent* event)
 {
     assert(window);
     assert(event);
-    return convertEvent(window->pollEvent(), event);
+    return convertEvent(window->pollEvent(), *event);
 }
 
 
@@ -123,7 +123,7 @@ bool sfWindow_waitEvent(sfWindow* window, sfTime timeout, sfEvent* event)
 {
     assert(window);
     assert(event);
-    return convertEvent(window->waitEvent(sf::microseconds(timeout.microseconds)), event);
+    return convertEvent(window->waitEvent(sf::microseconds(timeout.microseconds)), *event);
 }
 
 

--- a/src/CSFML/Window/WindowBase.cpp
+++ b/src/CSFML/Window/WindowBase.cpp
@@ -96,7 +96,7 @@ bool sfWindowBase_pollEvent(sfWindowBase* windowBase, sfEvent* event)
 {
     assert(windowBase);
     assert(event);
-    return convertEvent(windowBase->pollEvent(), event);
+    return convertEvent(windowBase->pollEvent(), *event);
 }
 
 
@@ -105,7 +105,7 @@ bool sfWindowBase_waitEvent(sfWindowBase* windowBase, sfTime timeout, sfEvent* e
 {
     assert(windowBase);
     assert(event);
-    return convertEvent(windowBase->waitEvent(sf::microseconds(timeout.microseconds)), event);
+    return convertEvent(windowBase->waitEvent(sf::microseconds(timeout.microseconds)), *event);
 }
 
 


### PR DESCRIPTION
sfEvent parameter was not checked for null and was assumed to be non null and wasn't an array in convertEvent so I made it a reference to reflect that.