### PR TITLE
Make enumeration counts constant expressions

### DIFF
--- a/include/CSFML/Window/Keyboard.h
+++ b/include/CSFML/Window/Keyboard.h
@@ -144,8 +144,10 @@ typedef enum
     sfKeyPause,        ///< The Pause key
 } sfKeyCode;
 
-CSFML_WINDOW_API const unsigned int sfKeyCount; ///< The total number of keyboard keys
-
+enum
+{
+    sfKeyCount = sfKeyPause + 1 ///< The total number of keyboard keys
+};
 
 ////////////////////////////////////////////////////////////
 /// \brief Scancodes
@@ -312,8 +314,10 @@ typedef enum
     sfScanLaunchMediaSelect,  //!< Keyboard Launch Media Select key
 } sfScancode;
 
-CSFML_WINDOW_API const unsigned int sfScancodeCount; //!< The total number of scancodes
-
+enum
+{
+    sfScancodeCount = sfScanLaunchMediaSelect + 1 //!< The total number of scancodes
+};
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a key is pressed

--- a/include/CSFML/Window/Mouse.h
+++ b/include/CSFML/Window/Mouse.h
@@ -46,7 +46,10 @@ typedef enum
     sfMouseButtonExtra2, ///< The second extra mouse button
 } sfMouseButton;
 
-CSFML_WINDOW_API const unsigned int sfMouseButtonCount; ///< The total number of mouse buttons
+enum
+{
+    sfMouseButtonCount = sfMouseButtonExtra2 + 1 ///< The total number of mouse buttons
+};
 
 ////////////////////////////////////////////////////////////
 /// \brief Mouse wheels

--- a/include/CSFML/Window/Sensor.h
+++ b/include/CSFML/Window/Sensor.h
@@ -47,8 +47,10 @@ typedef enum
     sfSensorOrientation, ///< Measures the absolute 3D orientation (degrees)
 } sfSensorType;
 
-CSFML_WINDOW_API const unsigned int sfSensorCount; ///< The total number of sensor types
-
+enum
+{
+    sfSensorCount = sfSensorOrientation + 1 ///< The total number of sensor types
+};
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a sensor is available on the underlying platform

--- a/src/CSFML/Window/Keyboard.cpp
+++ b/src/CSFML/Window/Keyboard.cpp
@@ -34,11 +34,6 @@
 
 
 ////////////////////////////////////////////////////////////
-const unsigned int sfKeyCount      = sfKeyPause + 1;
-const unsigned int sfScancodeCount = sfScanLaunchMediaSelect + 1;
-
-
-////////////////////////////////////////////////////////////
 bool sfKeyboard_isKeyPressed(sfKeyCode key)
 {
     return sf::Keyboard::isKeyPressed(static_cast<sf::Keyboard::Key>(key));

--- a/src/CSFML/Window/Mouse.cpp
+++ b/src/CSFML/Window/Mouse.cpp
@@ -34,10 +34,6 @@
 
 
 ////////////////////////////////////////////////////////////
-const unsigned int sfMouseButtonCount = sfMouseButtonExtra2 + 1;
-
-
-////////////////////////////////////////////////////////////
 bool sfMouse_isButtonPressed(sfMouseButton button)
 {
     return sf::Mouse::isButtonPressed(static_cast<sf::Mouse::Button>(button));

--- a/src/CSFML/Window/Sensor.cpp
+++ b/src/CSFML/Window/Sensor.cpp
@@ -32,10 +32,6 @@
 
 
 ////////////////////////////////////////////////////////////
-const unsigned int sfSensorCount = sfSensorOrientation + 1;
-
-
-////////////////////////////////////////////////////////////
 bool sfSensor_isAvailable(sfSensorType sensor)
 {
     return sf::Sensor::isAvailable(static_cast<sf::Sensor::Type>(sensor));

--- a/test/Window/Keyboard.test.cpp
+++ b/test/Window/Keyboard.test.cpp
@@ -14,7 +14,7 @@ TEST_CASE("[Window] sfKeyboard")
         STATIC_CHECK(sfKeyC == static_cast<int>(sf::Keyboard::Key::C));
         STATIC_CHECK(sfKeyD == static_cast<int>(sf::Keyboard::Key::D));
         STATIC_CHECK(sfKeyPause == static_cast<int>(sf::Keyboard::Key::Pause));
-        CHECK(sfKeyCount == sf::Keyboard::KeyCount);
+        STATIC_CHECK(sfKeyCount == sf::Keyboard::KeyCount);
     }
 
     SECTION("sfScancode")
@@ -24,6 +24,6 @@ TEST_CASE("[Window] sfKeyboard")
         STATIC_CHECK(sfScanB == static_cast<int>(sf::Keyboard::Scan::B));
         STATIC_CHECK(sfScanC == static_cast<int>(sf::Keyboard::Scan::C));
         STATIC_CHECK(sfScanD == static_cast<int>(sf::Keyboard::Scan::D));
-        CHECK(sfScancodeCount == sf::Keyboard::ScancodeCount);
+        STATIC_CHECK(sfScancodeCount == sf::Keyboard::ScancodeCount);
     }
 }

--- a/test/Window/Mouse.test.cpp
+++ b/test/Window/Mouse.test.cpp
@@ -13,7 +13,7 @@ TEST_CASE("[Window] sfMouse")
         STATIC_CHECK(sfMouseMiddle == static_cast<int>(sf::Mouse::Button::Middle));
         STATIC_CHECK(sfMouseButtonExtra1 == static_cast<int>(sf::Mouse::Button::Extra1));
         STATIC_CHECK(sfMouseButtonExtra2 == static_cast<int>(sf::Mouse::Button::Extra2));
-        CHECK(sfMouseButtonCount == sf::Mouse::ButtonCount);
+        STATIC_CHECK(sfMouseButtonCount == sf::Mouse::ButtonCount);
     }
 
     SECTION("sfMouseWheel")

--- a/test/Window/Sensor.test.cpp
+++ b/test/Window/Sensor.test.cpp
@@ -14,6 +14,6 @@ TEST_CASE("[Window] sfSensor")
         STATIC_CHECK(sfSensorGravity == static_cast<int>(sf::Sensor::Type::Gravity));
         STATIC_CHECK(sfSensorUserAcceleration == static_cast<int>(sf::Sensor::Type::UserAcceleration));
         STATIC_CHECK(sfSensorOrientation == static_cast<int>(sf::Sensor::Type::Orientation));
-        CHECK(sfSensorCount == sf::Sensor::Count);
+        STATIC_CHECK(sfSensorCount == sf::Sensor::Count);
     }
 }


### PR DESCRIPTION
This change allows now having these variables as array sizes that are not Variable Length Arrays like in structs for example.

```cpp
struct {
   sfKeycode keys[sfKeyCount]; // didn't compile since it was not constant expression
} global_table;

int main(void) {
   return 0;
}
```

To note however that this changes the type from unsigned int to an implementation defined type which usually `int` which is signed and not unsigned. and also disallows taking the address of the constant since it is mo longer a variable.

the other is using a macro which I don't like, but it can allow us to change the type to an unsigned type if we really wanted

```cpp
#define sfKeyCount ((unsigned int)sfKeyPause + 1)
```

but I prefer CSFML to be macro free if possible so I choose the enum approach.