### PR TITLE
Align sfRenderStates with sf::RenderStates

### DIFF
--- a/include/CSFML/Graphics/CoordinateType.h
+++ b/include/CSFML/Graphics/CoordinateType.h
@@ -25,33 +25,11 @@
 #pragma once
 
 ////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <CSFML/Graphics/Export.h>
-
-#include <CSFML/Graphics/BlendMode.h>
-#include <CSFML/Graphics/CoordinateType.h>
-#include <CSFML/Graphics/StencilMode.h>
-#include <CSFML/Graphics/Transform.h>
-#include <CSFML/Graphics/Types.h>
-
-
-////////////////////////////////////////////////////////////
-/// \brief Define the states used for drawing to a RenderTarget
+/// \brief Types of texture coordinates that can be used for rendering.
 ///
 ////////////////////////////////////////////////////////////
-typedef struct
+typedef enum
 {
-    sfBlendMode      blendMode;      ///< Blending mode
-    sfStencilMode    stencilMode;    //!< Stencil mode
-    sfTransform      transform;      ///< Transform
-    sfCoordinateType coordinateType; //!< Texture coordinate type
-    const sfTexture* texture;        ///< Texture
-    const sfShader*  shader;         ///< Shader
-} sfRenderStates;
-
-////////////////////////////////////////////////////////////
-/// \brief Define the default values for a RenderState
-///
-////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API const sfRenderStates sfRenderStates_default;
+    sfCoordinateTypeNormalized, ///< sfTexture coordinates in range [0 .. 1].
+    sfCoordinateTypePixels      ///< sfTexture coordinates in range [0 .. size].
+} sfCoordinateType;

--- a/include/CSFML/Graphics/Texture.h
+++ b/include/CSFML/Graphics/Texture.h
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <CSFML/Graphics/Export.h>
 
+#include <CSFML/Graphics/CoordinateType.h>
 #include <CSFML/Graphics/Rect.h>
 #include <CSFML/Graphics/Types.h>
 #include <CSFML/System/InputStream.h>
@@ -36,16 +37,6 @@
 #include <CSFML/Window/Types.h>
 
 #include <stddef.h>
-
-////////////////////////////////////////////////////////////
-/// \brief Types of texture coordinates that can be used for rendering.
-///
-////////////////////////////////////////////////////////////
-typedef enum
-{
-    sfTextureNormalized, ///< sfTexture coordinates in range [0 .. 1].
-    sfTexturePixels      ///< sfTexture coordinates in range [0 .. size].
-} sfTextureCoordinateType;
 
 ////////////////////////////////////////////////////////////
 /// \brief Create a new texture
@@ -400,7 +391,7 @@ CSFML_GRAPHICS_API unsigned int sfTexture_getNativeHandle(const sfTexture* textu
 /// \param type    Type of texture coordinates to use
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API void sfTexture_bind(const sfTexture* texture, sfTextureCoordinateType type);
+CSFML_GRAPHICS_API void sfTexture_bind(const sfTexture* texture, sfCoordinateType type);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the maximum texture size allowed

--- a/src/CSFML/Graphics/CMakeLists.txt
+++ b/src/CSFML/Graphics/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC
     ${SRCROOT}/ConvexShape.cpp
     ${SRCROOT}/ConvexShapeStruct.hpp
     ${INCROOT}/ConvexShape.h
+    ${INCROOT}/CoordinateType.h
     ${SRCROOT}/Font.cpp
     ${SRCROOT}/FontStruct.hpp
     ${INCROOT}/Font.h

--- a/src/CSFML/Graphics/ConvertRenderStates.hpp
+++ b/src/CSFML/Graphics/ConvertRenderStates.hpp
@@ -44,14 +44,21 @@
         return {};
 
     sf::RenderStates renderStates;
-    renderStates.blendMode.colorSrcFactor = static_cast<sf::BlendMode::Factor>(states->blendMode.colorSrcFactor);
-    renderStates.blendMode.colorDstFactor = static_cast<sf::BlendMode::Factor>(states->blendMode.colorDstFactor);
-    renderStates.blendMode.colorEquation  = static_cast<sf::BlendMode::Equation>(states->blendMode.colorEquation);
-    renderStates.blendMode.alphaSrcFactor = static_cast<sf::BlendMode::Factor>(states->blendMode.alphaSrcFactor);
-    renderStates.blendMode.alphaDstFactor = static_cast<sf::BlendMode::Factor>(states->blendMode.alphaDstFactor);
-    renderStates.blendMode.alphaEquation  = static_cast<sf::BlendMode::Equation>(states->blendMode.alphaEquation);
-    renderStates.transform                = convertTransform(states->transform);
-    renderStates.texture                  = states->texture ? states->texture->This : nullptr;
-    renderStates.shader                   = states->shader;
+    renderStates.blendMode.colorSrcFactor      = static_cast<sf::BlendMode::Factor>(states->blendMode.colorSrcFactor);
+    renderStates.blendMode.colorDstFactor      = static_cast<sf::BlendMode::Factor>(states->blendMode.colorDstFactor);
+    renderStates.blendMode.colorEquation       = static_cast<sf::BlendMode::Equation>(states->blendMode.colorEquation);
+    renderStates.blendMode.alphaSrcFactor      = static_cast<sf::BlendMode::Factor>(states->blendMode.alphaSrcFactor);
+    renderStates.blendMode.alphaDstFactor      = static_cast<sf::BlendMode::Factor>(states->blendMode.alphaDstFactor);
+    renderStates.blendMode.alphaEquation       = static_cast<sf::BlendMode::Equation>(states->blendMode.alphaEquation);
+    renderStates.stencilMode.stencilComparison = static_cast<sf::StencilComparison>(states->stencilMode.stencilComparison);
+    renderStates.stencilMode.stencilUpdateOperation = static_cast<sf::StencilUpdateOperation>(
+        states->stencilMode.stencilUpdateOperation);
+    renderStates.stencilMode.stencilReference.value = states->stencilMode.stencilReference.value;
+    renderStates.stencilMode.stencilMask.value      = states->stencilMode.stencilMask.value;
+    renderStates.stencilMode.stencilOnly            = states->stencilMode.stencilOnly;
+    renderStates.transform                          = convertTransform(states->transform);
+    renderStates.coordinateType                     = static_cast<sf::CoordinateType>(states->coordinateType);
+    renderStates.texture                            = states->texture ? states->texture->This : nullptr;
+    renderStates.shader                             = states->shader;
     return renderStates;
 }

--- a/src/CSFML/Graphics/RenderStates.cpp
+++ b/src/CSFML/Graphics/RenderStates.cpp
@@ -31,7 +31,9 @@
 ////////////////////////////////////////////////////////////
 const sfRenderStates sfRenderStates_default = {
     sfBlendAlpha,
+    sfStencilMode_default,
     sfTransform_Identity,
+    sfCoordinateTypePixels,
     nullptr,
     nullptr,
 };

--- a/src/CSFML/Graphics/Texture.cpp
+++ b/src/CSFML/Graphics/Texture.cpp
@@ -299,7 +299,7 @@ unsigned int sfTexture_getNativeHandle(const sfTexture* texture)
 
 
 ////////////////////////////////////////////////////////////
-void sfTexture_bind(const sfTexture* texture, sfTextureCoordinateType type)
+void sfTexture_bind(const sfTexture* texture, sfCoordinateType type)
 {
     sf::Texture::bind(texture ? texture->This : nullptr, static_cast<sf::CoordinateType>(type));
 }


### PR DESCRIPTION
Seems like I missed updating the actual struct while updating stencil related stuff.