### PR TITLE
Fix const correctness issues

### DIFF
--- a/include/CSFML/Graphics/VertexArray.h
+++ b/include/CSFML/Graphics/VertexArray.h
@@ -150,7 +150,7 @@ CSFML_GRAPHICS_API void sfVertexArray_setPrimitiveType(sfVertexArray* vertexArra
 /// \return Primitive type
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfPrimitiveType sfVertexArray_getPrimitiveType(sfVertexArray* vertexArray);
+CSFML_GRAPHICS_API sfPrimitiveType sfVertexArray_getPrimitiveType(const sfVertexArray* vertexArray);
 
 ////////////////////////////////////////////////////////////
 /// \brief Compute the bounding rectangle of a vertex array
@@ -163,4 +163,4 @@ CSFML_GRAPHICS_API sfPrimitiveType sfVertexArray_getPrimitiveType(sfVertexArray*
 /// \return Bounding rectangle of the vertex array
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API sfFloatRect sfVertexArray_getBounds(sfVertexArray* vertexArray);
+CSFML_GRAPHICS_API sfFloatRect sfVertexArray_getBounds(const sfVertexArray* vertexArray);

--- a/include/CSFML/Graphics/VertexBuffer.h
+++ b/include/CSFML/Graphics/VertexBuffer.h
@@ -166,7 +166,7 @@ CSFML_GRAPHICS_API void sfVertexBuffer_swap(sfVertexBuffer* left, sfVertexBuffer
 /// \return OpenGL handle of the vertex buffer or 0 if not yet created
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API unsigned int sfVertexBuffer_getNativeHandle(sfVertexBuffer* vertexBuffer);
+CSFML_GRAPHICS_API unsigned int sfVertexBuffer_getNativeHandle(const sfVertexBuffer* vertexBuffer);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the type of primitives to draw

--- a/src/CSFML/Graphics/VertexArray.cpp
+++ b/src/CSFML/Graphics/VertexArray.cpp
@@ -104,7 +104,7 @@ void sfVertexArray_setPrimitiveType(sfVertexArray* vertexArray, sfPrimitiveType 
 
 
 ////////////////////////////////////////////////////////////
-sfPrimitiveType sfVertexArray_getPrimitiveType(sfVertexArray* vertexArray)
+sfPrimitiveType sfVertexArray_getPrimitiveType(const sfVertexArray* vertexArray)
 {
     assert(vertexArray);
     return static_cast<sfPrimitiveType>(vertexArray->getPrimitiveType());
@@ -112,7 +112,7 @@ sfPrimitiveType sfVertexArray_getPrimitiveType(sfVertexArray* vertexArray)
 
 
 ////////////////////////////////////////////////////////////
-sfFloatRect sfVertexArray_getBounds(sfVertexArray* vertexArray)
+sfFloatRect sfVertexArray_getBounds(const sfVertexArray* vertexArray)
 {
     assert(vertexArray);
     return convertRect(vertexArray->getBounds());

--- a/src/CSFML/Graphics/VertexBuffer.cpp
+++ b/src/CSFML/Graphics/VertexBuffer.cpp
@@ -92,7 +92,7 @@ void sfVertexBuffer_swap(sfVertexBuffer* left, sfVertexBuffer* right)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int sfVertexBuffer_getNativeHandle(sfVertexBuffer* vertexBuffer)
+unsigned int sfVertexBuffer_getNativeHandle(const sfVertexBuffer* vertexBuffer)
 {
     assert(vertexBuffer);
     return vertexBuffer->getNativeHandle();


### PR DESCRIPTION
By requiring a non-const pointer we impose unnecessary restrictions that make user code a bit more cumbersome to write.