### PR TITLE
Avoid doing a real name resolution in sfIpAddress_fromString test

### DIFF
--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -22,7 +22,8 @@ TEST_CASE("[Network] sfIpAddress")
     SECTION("sfIpAddress_fromString")
     {
         CHECK(sfIpAddress_toInteger(sfIpAddress_fromString("")) == 0);
-        CHECK(sfIpAddress_toInteger(sfIpAddress_fromString("invalid address")) == 0);
+        CHECK(sfIpAddress_toInteger(sfIpAddress_fromString("256.256.256.256")) == 0);
+        CHECK(sfIpAddress_toInteger(sfIpAddress_fromString("localhost")) == 0x7F000001);
         CHECK(sfIpAddress_toInteger(sfIpAddress_fromString("192.168.0.1")) == 0xC0A80001);
         CHECK(sfIpAddress_toInteger(sfIpAddress_fromString("8.8.8.8")) == 0x08080808);
     }


### PR DESCRIPTION
On some PCs, resolving `invalid address` will perform a real name resolution using the network. This is slows down the test and risks the test failing if the resolution succeeds.

Use `localhost` instead which shold return a known value, and add an invalid ip address test for good measure.