### PR TITLE
Allow overriding protected methods on sfMusic and sfSoundStream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Get CMake and Ninja
       uses: lukka/get-cmake@latest
       with:
+        cmakeVersion: ${{ runner.os == 'Windows' && '3.25' || '3.22' }}
         ninjaVersion: latest
 
     - name: Install Linux Dependencies

--- a/include/CSFML/Audio/Music.h
+++ b/include/CSFML/Audio/Music.h
@@ -33,12 +33,23 @@
 #include <CSFML/Audio/SoundChannel.h>
 #include <CSFML/Audio/SoundSourceCone.h>
 #include <CSFML/Audio/SoundStatus.h>
+#include <CSFML/Audio/SoundStream.h>
 #include <CSFML/Audio/Types.h>
 #include <CSFML/System/InputStream.h>
 #include <CSFML/System/Time.h>
 #include <CSFML/System/Vector3.h>
 
 #include <stddef.h>
+
+
+typedef bool (*sfMusicOnGetDataOriginal)(sfMusic* music, sfSoundStreamChunk* data); ///< sf::Music::onGetData callback
+typedef bool (*sfMusicOnGetDataMixin)(sfMusicOnGetDataOriginal originalImpl, sfMusic* music, sfSoundStreamChunk* data); ///< sf::Music::onGetData mixin
+
+typedef void (*sfMusicOnSeekOriginal)(sfMusic* music, sfTime data); ///< sf::Music::onSeek callback
+typedef void (*sfMusicOnSeekMixin)(sfMusicOnSeekOriginal originalImpl, sfMusic* music, sfTime timeOffset); ///< sf::Music::onSeek mixin
+
+typedef bool (*sfMusicOnLoopOriginal)(sfMusic* music, uint64_t* position); ///< sf::Music::onLoop callback
+typedef bool (*sfMusicOnLoopMixin)(sfMusicOnLoopOriginal originalImpl, sfMusic* music, uint64_t* position); ///< sf::Music::onLoop mixin
 
 
 ////////////////////////////////////////////////////////////
@@ -50,6 +61,46 @@ typedef struct
     sfTime offset; ///< The beginning offset of the time range
     sfTime length; ///< The length of the time range
 } sfTimeSpan;
+
+
+////////////////////////////////////////////////////////////
+/// \brief Override the behaviour of requesting a new chunk
+///        of audio samples from the stream source
+///
+/// This function fills the chunk from the next samples
+/// to read from the audio file.
+///
+/// \param music Music object
+/// \param mixin Method override to set, a null override restores the original behaviour
+///
+////////////////////////////////////////////////////////////
+CSFML_AUDIO_API void sfMusic_setOnGetData(sfMusic* music, sfMusicOnGetDataMixin mixin);
+
+
+////////////////////////////////////////////////////////////
+/// \brief Override the behaviour of changing the current
+///        playing position in the stream source
+///
+/// \param music Music object
+/// \param mixin Method override to set, a null override restores the original behaviour
+///
+////////////////////////////////////////////////////////////
+CSFML_AUDIO_API void sfMusic_setOnSeek(sfMusic* music, sfMusicOnSeekMixin mixin);
+
+
+////////////////////////////////////////////////////////////
+/// \brief Override the behaviour of changing the current
+///        playing position in the stream source to the loop offset
+///
+/// This is called by the underlying `SoundStream` whenever it needs us to reset
+/// the seek position for a loop. We then determine whether we are looping on a
+/// loop point or the end-of-file, perform the seek, and return the new position.
+///
+/// \param music Music object
+/// \param mixin Method override to set, a null override restores the original behaviour
+///
+////////////////////////////////////////////////////////////
+CSFML_AUDIO_API void sfMusic_setOnLoop(sfMusic* music, sfMusicOnLoopMixin mixin);
 
 
 ////////////////////////////////////////////////////////////

--- a/include/CSFML/Audio/SoundStream.h
+++ b/include/CSFML/Audio/SoundStream.h
@@ -40,18 +40,36 @@
 #include <stddef.h>
 
 
+typedef bool (*sfSoundStreamOnLoopOriginal)(sfSoundStream* soundStream, uint64_t* position); ///< sf::SoundStream::onLoop callback
+typedef bool (*sfSoundStreamOnLoopMixin)(sfSoundStreamOnLoopOriginal, sfSoundStream* soundStream, uint64_t* position); ///< sf::SoundStream::onLoop mixin
+
+
 ////////////////////////////////////////////////////////////
 /// \brief defines the data to fill by the OnGetData callback
 ///
 ////////////////////////////////////////////////////////////
 typedef struct
 {
-    int16_t*     samples;     ///< Pointer to the audio samples
-    unsigned int sampleCount; ///< Number of samples pointed by Samples
+    const int16_t* samples;     ///< Pointer to the audio samples
+    size_t         sampleCount; ///< Number of samples pointed by Samples
 } sfSoundStreamChunk;
 
 typedef bool (*sfSoundStreamGetDataCallback)(sfSoundStreamChunk*, void*); ///< Type of the callback used to get a sound stream data
 typedef void (*sfSoundStreamSeekCallback)(sfTime, void*); ///< Type of the callback used to seek in a sound stream
+
+
+////////////////////////////////////////////////////////////
+/// \brief Override the behaviour of changing the current
+///        playing position in the stream source to the loop offset
+///
+/// This function can be overridden to allow implementation of
+/// custom loop points. Otherwise, it just calls `onSeek(Time::Zero)` and returns 0.
+///
+/// \param soundStream SoundStream object
+/// \param mixin       Method override to set, a null override restores the original behaviour
+///
+////////////////////////////////////////////////////////////
+CSFML_AUDIO_API void sfSoundStream_setOnLoop(sfSoundStream* soundStream, sfSoundStreamOnLoopMixin mixin);
 
 
 ////////////////////////////////////////////////////////////

--- a/src/CSFML/Audio/CMakeLists.txt
+++ b/src/CSFML/Audio/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
     ${INCROOT}/Listener.h
     ${SRCROOT}/Music.cpp
     ${SRCROOT}/MusicStruct.hpp
+    ${SRCROOT}/MusicStruct.cpp
     ${INCROOT}/Music.h
     ${SRCROOT}/Sound.cpp
     ${SRCROOT}/SoundStruct.hpp
@@ -27,6 +28,7 @@ set(SRC
     ${INCROOT}/SoundSourceCone.h
     ${INCROOT}/SoundStatus.h
     ${SRCROOT}/SoundStream.cpp
+    ${SRCROOT}/SoundStreamStruct.cpp
     ${SRCROOT}/SoundStreamStruct.hpp
     ${INCROOT}/SoundStream.h
     ${INCROOT}/Types.h

--- a/src/CSFML/Audio/Music.cpp
+++ b/src/CSFML/Audio/Music.cpp
@@ -34,6 +34,28 @@
 
 #include <cstring>
 
+
+////////////////////////////////////////////////////////////
+void sfMusic_setOnGetData(sfMusic* music, sfMusicOnGetDataMixin mixin)
+{
+    music->OnGetDataMixin = mixin;
+}
+
+
+////////////////////////////////////////////////////////////
+void sfMusic_setOnSeek(sfMusic* music, sfMusicOnSeekMixin mixin)
+{
+    music->OnSeekMixin = mixin;
+}
+
+
+////////////////////////////////////////////////////////////
+void sfMusic_setOnLoop(sfMusic* music, sfMusicOnLoopMixin mixin)
+{
+    music->OnLoopMixin = mixin;
+}
+
+
 ////////////////////////////////////////////////////////////
 sfMusic* sfMusic_createFromFile(const char* filename)
 {

--- a/src/CSFML/Audio/MusicStruct.cpp
+++ b/src/CSFML/Audio/MusicStruct.cpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2024 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <CSFML/Audio/MusicStruct.hpp>
+
+
+////////////////////////////////////////////////////////////
+bool sfMusic::onGetDataOriginal(sfMusic* music, sfSoundStreamChunk* data)
+{
+    sf::SoundStream::Chunk cppData;
+
+    cppData.samples     = data->samples;
+    cppData.sampleCount = data->sampleCount;
+
+    bool result = music->sf::Music::onGetData(cppData);
+
+    data->samples     = cppData.samples;
+    data->sampleCount = cppData.sampleCount;
+
+    return result;
+}
+
+
+////////////////////////////////////////////////////////////
+bool sfMusic::onGetData(sf::SoundStream::Chunk& data)
+{
+    if (!OnGetDataMixin)
+        return sf::Music::onGetData(data);
+
+    sfSoundStreamChunk cData;
+
+    cData.samples     = data.samples;
+    cData.sampleCount = data.sampleCount;
+
+    bool result = OnGetDataMixin(onGetDataOriginal, this, &cData);
+
+    data.samples     = cData.samples;
+    data.sampleCount = cData.sampleCount;
+
+    return result;
+}
+
+
+////////////////////////////////////////////////////////////
+void sfMusic::onSeekOriginal(sfMusic* music, sfTime timeOffset)
+{
+    return music->sf::Music::onSeek(sf::microseconds(timeOffset.microseconds));
+}
+
+
+////////////////////////////////////////////////////////////
+void sfMusic::onSeek(sf::Time timeOffset)
+{
+    if (!OnSeekMixin)
+        return sf::Music::onSeek(timeOffset);
+
+    return OnSeekMixin(onSeekOriginal, this, {timeOffset.asMicroseconds()});
+}
+
+
+////////////////////////////////////////////////////////////
+bool sfMusic::onLoopOriginal(sfMusic* music, uint64_t* position)
+{
+    auto result = music->sf::Music::onLoop();
+
+    if (!result)
+    {
+        return false;
+    }
+
+    *position = *result;
+    return true;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<std::uint64_t> sfMusic::onLoop()
+{
+    if (!OnLoopMixin)
+        return sf::Music::onLoop();
+
+    std::uint64_t data = 0;
+
+    bool noLoop = OnLoopMixin(onLoopOriginal, this, &data);
+
+    return noLoop ? std::nullopt : std::optional(data);
+}

--- a/src/CSFML/Audio/SoundStream.cpp
+++ b/src/CSFML/Audio/SoundStream.cpp
@@ -34,6 +34,13 @@
 
 
 ////////////////////////////////////////////////////////////
+void sfSoundStream_setOnLoop(sfSoundStream* soundStream, sfSoundStreamOnLoopMixin mixin)
+{
+    soundStream->OnLoopMixin = mixin;
+}
+
+
+////////////////////////////////////////////////////////////
 sfSoundStream* sfSoundStream_create(
     sfSoundStreamGetDataCallback onGetData,
     sfSoundStreamSeekCallback    onSeek,

--- a/src/CSFML/Audio/SoundStreamStruct.hpp
+++ b/src/CSFML/Audio/SoundStreamStruct.hpp
@@ -28,6 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <CSFML/Audio/SoundChannel.h>
+#include <CSFML/Audio/SoundStream.h>
 
 #include <SFML/Audio/SoundStream.hpp>
 
@@ -57,7 +58,6 @@ public:
 
     mutable std::vector<sfSoundChannel> Channels;
 
-private:
     bool onGetData(Chunk& data) override
     {
         sfSoundStreamChunk chunk = {nullptr, 0};
@@ -77,6 +77,10 @@ private:
             mySeekCallback(time, myUserData);
         }
     }
+
+    sfSoundStreamOnLoopMixin     OnLoopMixin = nullptr;
+    static bool                  onLoopOriginal(sfSoundStream* music, uint64_t* position);
+    std::optional<std::uint64_t> onLoop() override;
 
     sfSoundStreamGetDataCallback myGetDataCallback;
     sfSoundStreamSeekCallback    mySeekCallback;


### PR DESCRIPTION
Fixes !394.

Implements overriding for protected methods in `sfMusic` and `sfSoundStream` by using the pattern described [here](https://github.com/SFML/CSFML/issues/394#issuecomment-2667080660).

The Chunk struct was also updated since the data types were different from the ones used in the C++ library:
```cpp
// CSFML old struct
typedef struct
{
    int16_t*     samples;     ///< Pointer to the audio samples
    unsigned int sampleCount; ///< Number of samples pointed by Samples
} sfSoundStreamChunk;

// SFML's struct
struct Chunk
{
    const std::int16_t* samples{};     //!< Pointer to the audio samples
    std::size_t         sampleCount{}; //!< Number of samples pointed by Samples
};
```

Additionally, `ci.yml` was updated so that a newer version of CMake would be fetched. mirroring the current code in the SFML repo. Without this, CI would fail due to an unsupported old version (< 3.5) being fetched.