### PR TITLE
Remove `LIB_SUFFIX` reference

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -81,9 +81,9 @@ macro(csfml_add_library target)
 
     # add the install rule
     install(TARGETS ${target}
-            RUNTIME DESTINATION bin COMPONENT bin
-            LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT bin
-            ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT devel)
+            RUNTIME COMPONENT bin
+            LIBRARY COMPONENT bin
+            ARCHIVE COMPONENT devel)
 
     # define CSFML_STATIC if the build type is not set to 'shared'
     if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
`LIB_SUFFIX` is not a standard or usually set variable. Instead you should use the defaults coming from `GNUInstallDirs`