### PR TITLE
Add missing setMinimumSize and setMaximumSize window methods

### DIFF
--- a/include/CSFML/Graphics/RenderWindow.h
+++ b/include/CSFML/Graphics/RenderWindow.h
@@ -217,6 +217,28 @@ CSFML_GRAPHICS_API bool sfRenderWindow_isSrgb(const sfRenderWindow* renderWindow
 CSFML_GRAPHICS_API void sfRenderWindow_setSize(sfRenderWindow* renderWindow, sfVector2u size);
 
 ////////////////////////////////////////////////////////////
+/// \brief Set the minimum window rendering region size
+///
+/// Pass a `NULL` vector to unset the minimum size
+///
+/// \param renderWindow Render window object
+/// \param minimumSize  New minimum size, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API void sfRenderWindow_setMinimumSize(sfRenderWindow* renderWindow, const sfVector2u* minimumSize);
+
+////////////////////////////////////////////////////////////
+/// \brief Set the maximum window rendering region size
+///
+/// Pass a `NULL` vector to unset the maximum size
+///
+/// \param renderWindow Render window object
+/// \param maximumSize  New maximum size, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API void sfRenderWindow_setMaximumSize(sfRenderWindow* renderWindow, const sfVector2u* maximumSize);
+
+////////////////////////////////////////////////////////////
 /// \brief Change the title of a render window
 ///
 /// \param renderWindow Render window object

--- a/include/CSFML/Window/Window.h
+++ b/include/CSFML/Window/Window.h
@@ -281,6 +281,28 @@ CSFML_WINDOW_API sfVector2u sfWindow_getSize(const sfWindow* window);
 CSFML_WINDOW_API void sfWindow_setSize(sfWindow* window, sfVector2u size);
 
 ////////////////////////////////////////////////////////////
+/// \brief Set the minimum window rendering region size
+///
+/// Pass a `NULL` vector to unset the minimum size
+///
+/// \param window      Window object
+/// \param minimumSize New minimum size, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_WINDOW_API void sfWindow_setMinimumSize(sfWindow* window, const sfVector2u* minimumSize);
+
+////////////////////////////////////////////////////////////
+/// \brief Set the maximum window rendering region size
+///
+/// Pass a `NULL` vector to unset the maximum size
+///
+/// \param window      Window object
+/// \param maximumSize New maximum size, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_WINDOW_API void sfWindow_setMaximumSize(sfWindow* window, const sfVector2u* maximumSize);
+
+////////////////////////////////////////////////////////////
 /// \brief Change the title of a window
 ///
 /// \param window Window object

--- a/include/CSFML/Window/WindowBase.h
+++ b/include/CSFML/Window/WindowBase.h
@@ -237,6 +237,28 @@ CSFML_WINDOW_API sfVector2u sfWindowBase_getSize(const sfWindowBase* windowBase)
 CSFML_WINDOW_API void sfWindowBase_setSize(sfWindowBase* windowBase, sfVector2u size);
 
 ////////////////////////////////////////////////////////////
+/// \brief Set the minimum window rendering region size
+///
+/// Pass a `NULL` vector to unset the minimum size
+///
+/// \param windowBase  Window object
+/// \param minimumSize New minimum size, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_WINDOW_API void sfWindowBase_setMinimumSize(sfWindowBase* windowBase, const sfVector2u* minimumSize);
+
+////////////////////////////////////////////////////////////
+/// \brief Set the maximum window rendering region size
+///
+/// Pass a `NULL` vector to unset the maximum size
+///
+/// \param windowBase  Window object
+/// \param maximumSize New maximum size, in pixels
+///
+////////////////////////////////////////////////////////////
+CSFML_WINDOW_API void sfWindowBase_setMaximumSize(sfWindowBase* windowBase, const sfVector2u* maximumSize);
+
+////////////////////////////////////////////////////////////
 /// \brief Change the title of a window
 ///
 /// \param windowBase Window object

--- a/src/CSFML/Graphics/RenderWindow.cpp
+++ b/src/CSFML/Graphics/RenderWindow.cpp
@@ -199,6 +199,38 @@ void sfRenderWindow_setSize(sfRenderWindow* renderWindow, sfVector2u size)
 
 
 ////////////////////////////////////////////////////////////
+void sfRenderWindow_setMinimumSize(sfRenderWindow* renderWindow, const sfVector2u* minimumSize)
+{
+    assert(renderWindow);
+
+    if (minimumSize == nullptr)
+    {
+        renderWindow->setMinimumSize(std::nullopt);
+    }
+    else
+    {
+        renderWindow->setMinimumSize(convertVector2(*minimumSize));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void sfRenderWindow_setMaximumSize(sfRenderWindow* renderWindow, const sfVector2u* maximumSize)
+{
+    assert(renderWindow);
+
+    if (maximumSize == nullptr)
+    {
+        renderWindow->setMaximumSize(std::nullopt);
+    }
+    else
+    {
+        renderWindow->setMaximumSize(convertVector2(*maximumSize));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void sfRenderWindow_setTitle(sfRenderWindow* renderWindow, const char* title)
 {
     assert(renderWindow);

--- a/src/CSFML/Window/Window.cpp
+++ b/src/CSFML/Window/Window.cpp
@@ -160,6 +160,38 @@ void sfWindow_setSize(sfWindow* window, sfVector2u size)
 
 
 ////////////////////////////////////////////////////////////
+void sfWindow_setMinimumSize(sfWindow* window, const sfVector2u* minimumSize)
+{
+    assert(window);
+
+    if (minimumSize == nullptr)
+    {
+        window->setMinimumSize(std::nullopt);
+    }
+    else
+    {
+        window->setMinimumSize(convertVector2(*minimumSize));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void sfWindow_setMaximumSize(sfWindow* window, const sfVector2u* maximumSize)
+{
+    assert(window);
+
+    if (maximumSize == nullptr)
+    {
+        window->setMaximumSize(std::nullopt);
+    }
+    else
+    {
+        window->setMaximumSize(convertVector2(*maximumSize));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void sfWindow_setTitle(sfWindow* window, const char* title)
 {
     assert(window);

--- a/src/CSFML/Window/WindowBase.cpp
+++ b/src/CSFML/Window/WindowBase.cpp
@@ -34,6 +34,8 @@
 
 #include <SFML/Window/VideoMode.hpp>
 
+#include <optional>
+
 
 ////////////////////////////////////////////////////////////
 sfWindowBase* sfWindowBase_create(sfVideoMode mode, const char* title, uint32_t style, sfWindowState state)
@@ -138,6 +140,38 @@ void sfWindowBase_setSize(sfWindowBase* windowBase, sfVector2u size)
 {
     assert(windowBase);
     windowBase->setSize(convertVector2(size));
+}
+
+
+////////////////////////////////////////////////////////////
+void sfWindowBase_setMinimumSize(sfWindowBase* windowBase, const sfVector2u* minimumSize)
+{
+    assert(windowBase);
+
+    if (minimumSize == nullptr)
+    {
+        windowBase->setMinimumSize(std::nullopt);
+    }
+    else
+    {
+        windowBase->setMinimumSize(convertVector2(*minimumSize));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void sfWindowBase_setMaximumSize(sfWindowBase* windowBase, const sfVector2u* maximumSize)
+{
+    assert(windowBase);
+
+    if (maximumSize == nullptr)
+    {
+        windowBase->setMaximumSize(std::nullopt);
+    }
+    else
+    {
+        windowBase->setMaximumSize(convertVector2(*maximumSize));
+    }
 }
 
 


### PR DESCRIPTION
Looks like this was missed during the feature list implementation for CSFML 3.

SFML PR: https://github.com/SFML/SFML/pull/2519