### PR TITLE
Test with oldest possible CMake version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Get CMake and Ninja
       uses: lukka/get-cmake@latest
       with:
+        cmakeVersion: ${{ runner.os == 'Windows' && '3.25' || '3.22' }}
         ninjaVersion: latest
 
     - name: Install Linux Dependencies


### PR DESCRIPTION
Testing with our minimum CMake version has the benefit of ensuring our `cmake_minimum_required` version is correct but it also works around issues with CMake 4 not being compatible with SFML 3.0.0 which is still the version we're using in CI.