### PR TITLE
Remove VS2019 CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2019 x86,  os: windows-2019, flags: -AWin32 }
-        - { name: Windows VS2019 x64,  os: windows-2019, flags: -Ax64 }
         - { name: Windows VS2022 x86,  os: windows-2022, flags: -AWin32 }
         - { name: Windows VS2022 x64,  os: windows-2022, flags: -Ax64 }
         - { name: Windows ClangCL,     os: windows-2022, flags: -T ClangCL }


### PR DESCRIPTION
Microsoft will be removing these images on June 30th. Between now and it then it will be performing brownouts so let's remove these jobs before those brownouts hit in a few days.