### PR TITLE
Split texture's resize function into sRGB and non-sRGB

### DIFF
--- a/include/CSFML/Graphics/Texture.h
+++ b/include/CSFML/Graphics/Texture.h
@@ -185,12 +185,24 @@ CSFML_GRAPHICS_API void sfTexture_destroy(const sfTexture* texture);
 ///
 /// \param texture Texture to resize
 /// \param size Width and height of the texture
-/// \param sRgb `true` to enable sRGB conversion, `false` to disable it
 ///
 /// \return `true` if resizing was successful, `false` if it failed
 ///
 ////////////////////////////////////////////////////////////
-CSFML_GRAPHICS_API bool sfTexture_resize(sfTexture* texture, sfVector2u size, bool sRgb);
+CSFML_GRAPHICS_API bool sfTexture_resize(sfTexture* texture, sfVector2u size);
+
+////////////////////////////////////////////////////////////
+/// \brief Resize the texture with sRGB-enabled
+///
+/// If this function fails, the texture is left unchanged.
+///
+/// \param texture Texture to resize
+/// \param size Width and height of the texture
+///
+/// \return `true` if resizing was successful, `false` if it failed
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API bool sfTexture_resizeSrgb(sfTexture* texture, sfVector2u size);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the size of the texture

--- a/src/CSFML/Graphics/Texture.cpp
+++ b/src/CSFML/Graphics/Texture.cpp
@@ -171,11 +171,20 @@ void sfTexture_destroy(const sfTexture* texture)
 
 
 ////////////////////////////////////////////////////////////
-bool sfTexture_resize(sfTexture* texture, sfVector2u size, bool sRgb)
+bool sfTexture_resize(sfTexture* texture, sfVector2u size)
 {
     assert(texture);
     assert(texture->This);
-    return texture->This->resize(convertVector2(size), sRgb);
+    return texture->This->resize(convertVector2(size), false);
+}
+
+
+////////////////////////////////////////////////////////////
+bool sfTexture_resizeSrgb(sfTexture* texture, sfVector2u size)
+{
+    assert(texture);
+    assert(texture->This);
+    return texture->This->resize(convertVector2(size), true);
 }
 
 


### PR DESCRIPTION
With #177 we've implemented `sfTexture_resize`, but the function takes a `bool` for switching between RGB and non-RGB, which is counter to the `sfTexture_createX` methods that each have their own sRGB versions.

There are two ways forward:

- Merge the `createX` and `createSrgbX` methods
- Split the `resize` method

I believe the reason for the separate functions are two fold:

- Adding functionality without API break
- C doesn't know of default parameter values, so method duplication is the answer

This PR chooses the method split, so one doesn't need to always provide the boolean.